### PR TITLE
DB hierarchy refactor

### DIFF
--- a/snorkel/contrib/snark/parser.py
+++ b/snorkel/contrib/snark/parser.py
@@ -31,7 +31,7 @@ class SparkCorpusParser(object):
 
     def _clear(self):
         # TODO
-        # session.query(Context).delete()
+        # session.query(Document).delete()
         # # We cannot cascade up from child contexts to parent Candidates,
         # # so we delete all Candidates too
         # session.query(Candidate).delete()

--- a/snorkel/models/candidate.py
+++ b/snorkel/models/candidate.py
@@ -161,12 +161,12 @@ def candidate_subclass(class_name, args, table_name=None, cardinality=None, valu
                 Integer, ForeignKey(arg_type.__tablename__+'.id', ondelete='CASCADE'), index=True)
             class_attribs[arg] = relationship(
                 arg_type.__name__,
-                # backref=backref(
-                #     table_name + '_' + arg + 's',
-                #     cascade_backrefs=False,
-                #     cascade='all, delete-orphan'
-                # ),
-                # cascade_backrefs=False,
+                backref=backref(
+                    table_name + '_' + arg + 's',
+                    cascade_backrefs=False,
+                    cascade='all, delete-orphan'
+                ),
+                cascade_backrefs=False,
                 foreign_keys=class_attribs[arg + '_id']
             )
             unique_args.append(class_attribs[arg + '_id'])

--- a/snorkel/models/context.py
+++ b/snorkel/models/context.py
@@ -152,7 +152,9 @@ class TemporaryContext(object):
             else:
                 insert_args = self._get_insert_args()
                 insert_args['stable_id'] = stable_id
-                self.id = session.execute(text(self._get_insert_query()), insert_args).inserted_primary_key[0]
+                span = Span(**insert_args)
+                session.add(span)
+                self.id = span.id
 
     def __eq__(self, other):
         raise NotImplementedError()
@@ -170,9 +172,6 @@ class TemporaryContext(object):
         raise NotImplementedError()
 
     def _get_table_name(self):
-        raise NotImplementedError()
-
-    def _get_insert_query(self):
         raise NotImplementedError()
 
     def _get_insert_args(self):
@@ -216,16 +215,6 @@ class TemporarySpan(TemporaryContext):
 
     def _get_polymorphic_identity(self):
         return 'span'
-
-    def _get_insert_query(self):
-        # According to the schema: 
-        # stable_id   | character varying | not null
-        # id          | integer           | not null default nextval('span_id_seq'::regclass)
-        # sentence_id | integer           | 
-        # char_start  | integer           | not null
-        # char_end    | integer           | not null
-        # meta        | bytea             | 
-        return """INSERT INTO span VALUES(:stable_id, DEFAULT, :sentence_id, :char_start, :char_end, :meta)"""
 
     def _get_insert_args(self):
         return {'sentence_id' : self.sentence.id,

--- a/snorkel/models/context.py
+++ b/snorkel/models/context.py
@@ -152,6 +152,12 @@ class TemporaryContext(object):
                 insert_args['stable_id'] = stable_id
                 span = Span(**insert_args)
                 session.add(span)
+
+                # Make sure that the ID gets assigned. This seems inefficient.
+                # The basic issue is that before, Snorkel was executing a manual INSERT statement on the session (also inefficient)...
+                # We call this for every promoted/added Span object such that we can make sure it has a valid ID by the time we want to create the candidate
+                # This is equivalent with the previous behavior, but seems inefficient but we rely on manually pushing these IDs around
+                session.flush()
                 self.id = span.id
 
     def __eq__(self, other):

--- a/snorkel/models/context.py
+++ b/snorkel/models/context.py
@@ -142,13 +142,11 @@ class TemporaryContext(object):
     def load_id_or_insert(self, session):
         if self.id is None:
             stable_id = self.get_stable_id()
-
-            table_name = self._get_table_name()
-            query_str = "SELECT id from " + table_name + " WHERE " + table_name + ".stable_id = '" + stable_id + "'"
-            existing = session.execute(query_str).fetchall()
+            Table = self._get_table_class()
+            existing = session.execute(select([Table.id]).where(Table.stable_id == stable_id)).first()
 
             if existing:
-                self.id = existing[0][0]
+                self.id = existing.id
             else:
                 insert_args = self._get_insert_args()
                 insert_args['stable_id'] = stable_id
@@ -171,7 +169,7 @@ class TemporaryContext(object):
     def get_stable_id(self):
         raise NotImplementedError()
 
-    def _get_table_name(self):
+    def _get_table_class(self):
         raise NotImplementedError()
 
     def _get_insert_args(self):
@@ -210,8 +208,8 @@ class TemporarySpan(TemporaryContext):
     def get_stable_id(self):
         return construct_stable_id(self.sentence, self._get_polymorphic_identity(), self.char_start, self.char_end)
 
-    def _get_table_name(self):
-        return 'span'
+    def _get_table_class(self):
+        return Span
 
     def _get_polymorphic_identity(self):
         return 'span'

--- a/snorkel/parser/corpus_parser.py
+++ b/snorkel/parser/corpus_parser.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from builtins import *
 
 from snorkel.parser.spacy_parser import Spacy
-from snorkel.models import Candidate, Context, Sentence
+from snorkel.models import Candidate, Context, Sentence, Document
 from snorkel.udf import UDF, UDFRunner
 
 
@@ -17,7 +17,7 @@ class CorpusParser(UDFRunner):
                                            parser=self.parser,
                                            fn=fn)
     def clear(self, session, **kwargs):
-        session.query(Context).delete()
+        session.query(Document).delete()
         # We cannot cascade up from child contexts to parent Candidates,
         # so we delete all Candidates too
         session.query(Candidate).delete()

--- a/snorkel/udf.py
+++ b/snorkel/udf.py
@@ -162,15 +162,32 @@ class UDF(Process):
         This method is called when the UDF is run as a Process in a multiprocess setting
         The basic routine is: get from JoinableQueue, apply, put / add outputs, loop
         """
+        insert_batch = set()
+        # Every 2,000 objects, we trigger a bulk insert
+        INSERT_BATCH_SIZE = 2000
+
         while True:
             try:
                 x = self.in_queue.get_nowait()
                 for y in self.apply(x, **self.apply_kwargs):
                     # If there's no additional reduce step coming, add to session
                     if self.add_to_session:
-                        self.session.add(y)
+                        # Without batching, we'd just call
+                        #   self.session.add(y)
+                        # However, this seems to get everything inserted at the very end.
+                        insert_batch.add(y)
+
+                        if len(insert_batch) >= INSERT_BATCH_SIZE:
+                            self.session.bulk_save_objects(insert_batch)
+                            insert_batch.clear()
+
                     else:
                         self.out_queue.put(y)
+
+                # Insert the remaining items queued up
+                self.session.bulk_save_objects(insert_batch)
+                insert_batch.clear()
+
                 self.in_queue.task_done()
                 self.out_queue.put(UDF.TASK_DONE_SENTINEL)
 

--- a/tutorials/crowdsourcing/Crowdsourced_Sentiment_Analysis.ipynb
+++ b/tutorials/crowdsourcing/Crowdsourced_Sentiment_Analysis.ipynb
@@ -252,11 +252,11 @@
    },
    "outputs": [],
    "source": [
-    "from snorkel.models import Context, Candidate\n",
+    "from snorkel.models import Document, Context, Candidate\n",
     "from snorkel.contrib.models.text import RawText\n",
     "\n",
     "# Make sure DB is cleared\n",
-    "session.query(Context).delete()\n",
+    "session.query(Document).delete()\n",
     "session.query(Candidate).delete()\n",
     "\n",
     "# Now we create the candidates with a simple loop\n",


### PR DESCRIPTION
These changes refactor in our model hierarchy to eliminate `Context` as the in-between uber-class that everything inherits from. Rather than having corresponding entries in the `context` table and operating via joined table inheritance, `Sentence`, `Document`, `Span`, etc. all now have their own tables. This speeds up insertion and other queries significantly.

This means that `candidate_subclass()` now needs to keep track of the types of its args.

@ajratner This is somewhat invasive and related to our discussion. I find the code in `PretaggedCandidateExtractorUDF` pretty hard to follow, but this does pass all of our tests for labeling & generative model on our side now.