### PR TITLE
Parser encoding fix

### DIFF
--- a/snorkel/parser/parser.py
+++ b/snorkel/parser/parser.py
@@ -25,10 +25,7 @@ class Parser(object):
         :return:
         '''
         if sys.version_info[0] < 3 and not isinstance(text, unicode):
-            text_alt = text.encode('utf-8', 'error')
-            text_alt = text_alt.decode('string_escape', errors='ignore')
-            text_alt = text_alt.decode('utf-8')
-            return text_alt
+            return unicode(text, errors='ignore')
         else:
             return text
 

--- a/snorkel/parser/parser.py
+++ b/snorkel/parser/parser.py
@@ -24,7 +24,7 @@ class Parser(object):
         :param text:
         :return:
         '''
-        if sys.version_info[0] < 3:
+        if sys.version_info[0] < 3 and not isinstance(text, unicode):
             text_alt = text.encode('utf-8', 'error')
             text_alt = text_alt.decode('string_escape', errors='ignore')
             text_alt = text_alt.decode('utf-8')

--- a/snorkel/parser/parser.py
+++ b/snorkel/parser/parser.py
@@ -25,7 +25,12 @@ class Parser(object):
         :return:
         '''
         if sys.version_info[0] < 3 and not isinstance(text, unicode):
-            return unicode(text, errors='ignore')
+            try:
+                return unicode(text, errors='ignore')
+            except Exception as error:
+                print("Failed to decode for parsing:")
+                print(text)
+                raise(error)
         else:
             return text
 


### PR DESCRIPTION
Skip unicode dance if input is already unicode.

Let me know if I'm missing something. I may not be getting the point of the string unescaping here in python2 mode.