### PR TITLE
Fix is_package indentation bug

### DIFF
--- a/snorkel/parser/spacy_parser.py
+++ b/snorkel/parser/spacy_parser.py
@@ -84,7 +84,7 @@ class Spacy(Parser):
         for package in packages:
             if package.lower().replace('-', '_') == name:
                 return True
-            return False
+        return False
 
     @staticmethod
     def model_installed(name):


### PR DESCRIPTION
Encountered this bug while playing around with snorkel.

The bug was that we never go through a single iteration of the loop because either True is returned or False is immediately returned. Instead we should be looping through all packages, and if True is never returned, False should be returned.