### PR TITLE
Add cleaner defaults to SliceClassifier

### DIFF
--- a/snorkel/classification/data.py
+++ b/snorkel/classification/data.py
@@ -34,7 +34,7 @@ class DictDataset(Dataset):
     Raises
     ------
     ValueError
-        All values in the Y_dict must be of type torch.Tensor
+        All values in the ``Y_dict`` must be of type torch.Tensor
 
     Attributes
     ----------
@@ -89,7 +89,7 @@ class DictDataset(Dataset):
         task_name: str = DEFAULT_TASK_NAME,
         dataset_name: str = DEFAULT_DATASET_NAME,
     ) -> "DictDataset":
-        """Initialize a DictDataset from PyTorch Tensors.
+        """Initialize a ``DictDataset`` from PyTorch Tensors.
 
         Parameters
         ----------
@@ -100,9 +100,9 @@ class DictDataset(Dataset):
         split
             Name of data split corresponding to this dataset.
         input_data_key
-            Name of data field to initialize in X_dict
+            Name of data field to initialize in ``X_dict``
         task_name
-            Name of task and corresponding label key in Y_dict
+            Name of task and corresponding label key in ``Y_dict``
         dataset_name
             Name of DictDataset to be initialized; See ``__init__`` above.
 

--- a/snorkel/classification/data.py
+++ b/snorkel/classification/data.py
@@ -10,6 +10,11 @@ XDict = Dict[str, Any]
 YDict = Dict[str, Tensor]
 Batch = Tuple[XDict, YDict]
 
+# Default string names for initializing a DictDataset
+DEFAULT_INPUT_DATA_KEY = "input_data"
+DEFAULT_DATASET_NAME = "SnorkelDataset"
+DEFAULT_TASK_NAME = "task"
+
 
 class DictDataset(Dataset):
     """A dataset where both the data fields and labels are stored in as dictionaries.
@@ -72,6 +77,45 @@ class DictDataset(Dataset):
             f"(name={self.name}, "
             f"X_keys={list(self.X_dict.keys())}, "
             f"Y_keys={list(self.Y_dict.keys())})"
+        )
+
+    @classmethod
+    def from_tensors(
+        cls,
+        X_tensor: Tensor,
+        Y_tensor: Tensor,
+        split: str,
+        input_data_key: str = DEFAULT_INPUT_DATA_KEY,
+        task_name: str = DEFAULT_TASK_NAME,
+        dataset_name: str = DEFAULT_DATASET_NAME,
+    ) -> "DictDataset":
+        """Initialize a DictDataset from PyTorch Tensors.
+
+        Parameters
+        ----------
+        X_tensor
+            Input data of shape [num_examples, feature_dim]
+        Y_tensor
+            Labels of shape [num_samples, num_classes]
+        split
+            Name of data split corresponding to this dataset.
+        input_data_key
+            Name of data field to initialize in X_dict
+        task_name
+            Name of task and corresponding label key in Y_dict
+        dataset_name
+            Name of DictDataset to be initialized; See ``__init__`` above.
+
+        Returns
+        -------
+        DictDataset
+            Class initialized with single task and label corresponding to input data
+        """
+        return cls(
+            name=dataset_name,
+            split=split,
+            X_dict={input_data_key: X_tensor},
+            Y_dict={task_name: Y_tensor},
         )
 
 

--- a/snorkel/slicing/slicing_classifier.py
+++ b/snorkel/slicing/slicing_classifier.py
@@ -7,6 +7,7 @@ import torch.nn as nn
 
 from snorkel.analysis import Scorer
 from snorkel.classification import DictDataLoader, DictDataset, Operation, Task
+from snorkel.classification.data import DEFAULT_INPUT_DATA_KEY, DEFAULT_TASK_NAME
 from snorkel.classification.multitask_classifier import MultitaskClassifier
 
 from .utils import add_slice_labels, convert_to_slice_tasks
@@ -47,8 +48,8 @@ class SlicingClassifier(MultitaskClassifier):
         base_architecture: nn.Module,
         head_dim: int,
         slice_names: List[str],
-        input_data_key: str,
-        task_name: str,
+        input_data_key: str = DEFAULT_INPUT_DATA_KEY,
+        task_name: str = DEFAULT_TASK_NAME,
         scorer: Scorer = Scorer(metrics=["accuracy", "f1"]),
         **multitask_kwargs: Any,
     ) -> None:

--- a/test/classification/test_data.py
+++ b/test/classification/test_data.py
@@ -3,6 +3,11 @@ import unittest
 import torch
 
 from snorkel.classification import DictDataLoader, DictDataset
+from snorkel.classification.data import (
+    DEFAULT_DATASET_NAME,
+    DEFAULT_INPUT_DATA_KEY,
+    DEFAULT_TASK_NAME,
+)
 
 
 class DatasetTest(unittest.TestCase):
@@ -29,6 +34,14 @@ class DatasetTest(unittest.TestCase):
         self.assertEqual(
             repr(dataset),
             "DictDataset(name=new_data, X_keys=['data1'], Y_keys=['task1'])",
+        )
+
+        # Test from_tensors inits with default values
+        dataset = DictDataset.from_tensors(x1, y1, "train")
+        self.assertEqual(
+            repr(dataset),
+            f"DictDataset(name={DEFAULT_DATASET_NAME}, "
+            f"X_keys=['{DEFAULT_INPUT_DATA_KEY}'], Y_keys=['{DEFAULT_TASK_NAME}'])",
         )
 
     def test_classifier_dataloader(self):


### PR DESCRIPTION
**Changes**

* `DictDataset` can now be initialized with `from_tensors` class function, which accepts PyTorch tensors
* `SliceClassifier` now uses a default for `input_data_key` and `task_name`

**Test Plan**
* Added test for `from_tensors`
* `tox` passes