### PR TITLE
Check number of LFs for LabelModel Input

### DIFF
--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -547,6 +547,8 @@ class LabelModel(nn.Module):
 
     def _set_constants(self, L: np.ndarray) -> None:
         self.n, self.m = L.shape
+        if self.m < 3:
+            raise ValueError(f"L_train should have at least 3 labeling functions")
         self.t = 1
 
     def _create_tree(self) -> None:

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -38,6 +38,10 @@ class LabelModelTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "L_train has cardinality"):
             label_model.fit(L, n_epochs=1)
 
+        L = np.array([[0], [1], [-1]])
+        with self.assertRaisesRegex(ValueError, "L_train should have at least 3"):
+            label_model.fit(L, n_epochs=1)
+
     def test_class_balance(self):
         label_model = LabelModel(cardinality=2, verbose=False)
         # Test class balance


### PR DESCRIPTION
## Description of proposed changes
Raise a `ValueError` if the number of labeling functions input to the LabelModel is less than 3

## Related issue(s)
#1427

Fixes #1426 and #1427 

## Test plan
Add test to check ValueError raised

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.