### PR TITLE
Remove conda mention from CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ tox --devenv .env
 
 Running `tox --devenv .env` will install create a virtual environment with Snorkel
 and all of its dependencies installed in the directory `.env`.
-This can be used in a number of ways, e.g. with `conda activate`
+This can be used in a number of ways, e.g. with `source .env/bin/activate`
 or for [linting in VSCode](https://code.visualstudio.com/docs/python/environments#_where-the-extension-looks-for-environments).
 For example, you can simply activate this environment and start using Snorkel:
 


### PR DESCRIPTION
## Description of proposed changes

We rely on dependency installation via pip for dev, not conda. Removing conda suggestion since 1. it doesn't work and 2. our requirements are based on PyPI versions and tox installs them into the virtualenv via pip.

## Test plan

Commands work locally
