### PR TITLE
Make preds and probs optional in Scorer.score()

### DIFF
--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -30,7 +30,7 @@ def metric_score(
     preds
         An array of (int) predictions
     probs
-        An [n_datapoints, n_classes] array of probabilistic predictions
+        An [n_datapoints, n_classes] array of probabilistic (float) predictions
     metric
         The name of the metric to calculate
     filter_dict

--- a/snorkel/analysis/scorer.py
+++ b/snorkel/analysis/scorer.py
@@ -68,16 +68,20 @@ class Scorer:
         preds: Optional[np.ndarray] = None,
         probs: Optional[np.ndarray] = None,
     ) -> Dict[str, float]:
-        """Calculate one or more scores from user-specified and/or user-defined metrics.
+        """Calculate scores for one or more user-specified metrics.
 
         Parameters
         ----------
         golds
-            Gold (aka ground truth) labels (integers)
+            An array of gold (int) labels to base scores on
         preds
-            Predictions (integers)
-        probs:
-            Probabilities (floats)
+            An [n_datapoints,] or [n_datapoints, 1] array of (int) predictions to score
+        probs
+            An [n_datapoints, n_classes] array of probabilistic (float) predictions
+
+        Because most metrics require either `preds` or `probs`, but not both, these
+        values are optional; it is up to the metric function that will be called  to
+        raise an exception if a field it requires is not passed to the `score()` method.
 
         Returns
         -------

--- a/snorkel/analysis/scorer.py
+++ b/snorkel/analysis/scorer.py
@@ -63,7 +63,10 @@ class Scorer:
         self.abstain_label = abstain_label
 
     def score(
-        self, golds: np.ndarray, preds: np.ndarray, probs: np.ndarray
+        self,
+        golds: np.ndarray,
+        preds: Optional[np.ndarray] = None,
+        probs: Optional[np.ndarray] = None,
     ) -> Dict[str, float]:
         """Calculate one or more scores from user-specified and/or user-defined metrics.
 

--- a/test/analysis/test_scorer.py
+++ b/test/analysis/test_scorer.py
@@ -51,6 +51,11 @@ class ScorerTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Cannot score"):
             scorer.score([], [], [])
 
+    def test_no_probs(self) -> None:
+        scorer = Scorer()
+        golds, preds, probs = self._get_labels()
+        self.assertEqual(scorer.score(golds, preds), scorer.score(golds, preds, probs))
+
     def test_abstain_labels(self) -> None:
         # We abstain on the last example by convention (label=-1)
         golds = np.array([1, 0, 1, 0, -1])


### PR DESCRIPTION
## Description of proposed changes
Make preds and probs optional for Scorer.score(), since it's just a wrapper around individual metric computation calls (usually via `metric_score`), and those metrics raise an Exception if they've been passed a `None` where they expected values. This change removes boilerplate from score() and loses no protection.

## Related issue(s)

Fixes #1417 

## Test plan
Add new test confirming that Scorer.score() can be called with or without probs.

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
