### PR TITLE
LabelModel parameter clamping fix (fixes issue 1422)

### DIFF
--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -60,7 +60,7 @@ class TrainConfig(Config):
     prec_init: float = 0.7
     seed: int = np.random.randint(1e6)
     log_freq: int = 10
-    mu_eps: float = -1.0
+    mu_eps: Optional[float] = None
 
 
 class LabelModelConfig(Config):
@@ -810,10 +810,10 @@ class LabelModel(nn.Module):
         # Note: Use user-provided value, else default to 1 / n', where n' is n rounded
         # to the closest power of ten; this rounding is done to make it more obvious
         # when the parameters have been clamped.
-        if self.train_config.mu_eps >= 0:
+        if self.train_config.mu_eps is not None:
             mu_eps = self.train_config.mu_eps
         else:
-            mu_eps = min(0.01, 1 / 10 ** np.round(np.log10(self.n)))
+            mu_eps = min(0.01, 1 / 10 ** np.ceil(np.log10(self.n)))
         self.mu.data = self.mu.clamp(mu_eps, 1 - mu_eps)  # type: ignore
 
         # Return model to eval mode

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -806,7 +806,7 @@ class LabelModel(nn.Module):
         # Clamp learned parameters
         # Note: If mu_clamp_min is set too high, e.g. in sparse settings where LFs
         # mostly abstain, this will cause null results!
-        self.mu.data = self.mu.clamp(
+        self.mu.data = self.mu.clamp(  # type: ignore
             self.train_config.mu_clamp_min,
             1 - self.train_config.mu_clamp_min
         )

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -807,8 +807,7 @@ class LabelModel(nn.Module):
         # Note: If mu_clamp_min is set too high, e.g. in sparse settings where LFs
         # mostly abstain, this will cause null results!
         self.mu.data = self.mu.clamp(  # type: ignore
-            self.train_config.mu_clamp_min,
-            1 - self.train_config.mu_clamp_min
+            self.train_config.mu_clamp_min, 1 - self.train_config.mu_clamp_min
         )
 
         # Return model to eval mode

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -813,7 +813,7 @@ class LabelModel(nn.Module):
         if self.train_config.mu_eps >= 0:
             mu_eps = self.train_config.mu_eps
         else:
-            mu_eps = 1 / 10 ** np.round(np.log10(self.n))
+            mu_eps = min(0.01, 1 / 10 ** np.round(np.log10(self.n)))
         self.mu.data = self.mu.clamp(mu_eps, 1 - mu_eps)  # type: ignore
 
         # Return model to eval mode

--- a/snorkel/synthetic/synthetic_data.py
+++ b/snorkel/synthetic/synthetic_data.py
@@ -4,7 +4,7 @@ import numpy as np
 
 
 def generate_simple_label_matrix(
-    n: int, m: int, cardinality: int
+    n: int, m: int, cardinality: int, abstain_multiplier: float = 1.0
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Generate a synthetic label matrix with true parameters and labels.
 
@@ -20,6 +20,8 @@ def generate_simple_label_matrix(
         Number of labeling functions
     cardinality
         Cardinality of true labels (i.e. not including abstains)
+    abstain_multiplier
+        Factor to multiply the probability of abstaining by
 
     Returns
     -------
@@ -34,7 +36,15 @@ def generate_simple_label_matrix(
     P = np.empty((m, cardinality + 1, cardinality))
     for i in range(m):
         p = np.random.rand(cardinality + 1, cardinality)
+
+        # Bias the LFs to being non-adversarial
         p[1:, :] += (cardinality - 1) * np.eye(cardinality)
+
+        # Optionally increase the abstain probability by some multiplier; note this is
+        # to simulate the common setting where LFs label very sparsely
+        p[0, :] *= abstain_multiplier
+
+        # Normalize the conditional probabilities table
         P[i] = p @ np.diag(1 / p.sum(axis=0))
 
     # Generate the true datapoint labels

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -201,7 +201,7 @@ class LabelModelTest(unittest.TestCase):
         L = np.array([[0, 1, 0], [0, 1, 0]])
         label_model = self._set_up_model(L)
 
-        label_model.mu = nn.Parameter(label_model.mu_init.clone())
+        label_model.mu = nn.Parameter(label_model.mu_init.clone().clamp(0.01, 0.99))
         probs = label_model.predict_proba(L)
 
         # with matching labels from 3 LFs, predicted probs clamped at (0.99,0.01)
@@ -212,7 +212,7 @@ class LabelModelTest(unittest.TestCase):
         L = np.array([[0, 1, 0], [0, 1, 0]])
         label_model = self._set_up_model(L)
 
-        label_model.mu = nn.Parameter(label_model.mu_init.clone())
+        label_model.mu = nn.Parameter(label_model.mu_init.clone().clamp(0.01, 0.99))
         preds = label_model.predict(L)
 
         true_preds = np.array([0, 0])
@@ -225,7 +225,7 @@ class LabelModelTest(unittest.TestCase):
     def test_score(self):
         L = np.array([[1, 0, 1], [1, 0, 1]])
         label_model = self._set_up_model(L)
-        label_model.mu = nn.Parameter(label_model.mu_init.clone())
+        label_model.mu = nn.Parameter(label_model.mu_init.clone().clamp(0.01, 0.99))
 
         results = label_model.score(L, Y=np.array([0, 1]))
         results_expected = dict(accuracy=0.5)

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -344,6 +344,16 @@ class LabelModelTest(unittest.TestCase):
             lr_scheduler_config = {"warmup_steps": 1, "warmup_unit": "batches"}
             label_model.fit(L, lr_scheduler_config=lr_scheduler_config)
 
+    def test_set_mu_eps(self):
+        MU_EPS = 0.0123
+
+        # Construct a label matrix such that P(\lambda_1 = 0 | Y) = 0.0, so it will hit
+        # the mu_eps floor
+        L = np.array([[1, 1, 1], [1, 1, 1]])
+        label_model = LabelModel(verbose=False)
+        label_model.fit(L, mu_eps=MU_EPS)
+        self.assertAlmostEqual(label_model._get_conditional_probs(0)[1, 0], MU_EPS)
+
 
 @pytest.mark.complex
 class TestLabelModelAdvanced(unittest.TestCase):

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -345,14 +345,14 @@ class LabelModelTest(unittest.TestCase):
             label_model.fit(L, lr_scheduler_config=lr_scheduler_config)
 
     def test_set_mu_eps(self):
-        MU_EPS = 0.0123
+        mu_eps = 0.0123
 
         # Construct a label matrix such that P(\lambda_1 = 0 | Y) = 0.0, so it will hit
         # the mu_eps floor
         L = np.array([[1, 1, 1], [1, 1, 1]])
         label_model = LabelModel(verbose=False)
-        label_model.fit(L, mu_eps=MU_EPS)
-        self.assertAlmostEqual(label_model._get_conditional_probs(0)[1, 0], MU_EPS)
+        label_model.fit(L, mu_eps=mu_eps)
+        self.assertAlmostEqual(label_model._get_conditional_probs(0)[1, 0], mu_eps)
 
 
 @pytest.mark.complex
@@ -372,7 +372,7 @@ class TestLabelModelAdvanced(unittest.TestCase):
 
         # Train LabelModel
         label_model = LabelModel(cardinality=self.cardinality, verbose=False)
-        label_model.fit(L, n_epochs=1000, lr=0.01, seed=123)
+        label_model.fit(L, n_epochs=200, lr=0.01, seed=123)
 
         # Test estimated LF conditional probabilities
         P_lm = label_model._get_conditional_probs().reshape(

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -355,10 +355,9 @@ class TestLabelModelAdvanced(unittest.TestCase):
         self.n = 10000  # Number of data points
         self.cardinality = 2  # Number of classes
 
-    def test_label_model(self) -> None:
+    def _test_label_model(self, P : np.ndarray, Y : np.ndarray, L : np.ndarray) -> None:
         """Test the LabelModel's estimate of P and Y."""
         np.random.seed(123)
-        P, Y, L = generate_simple_label_matrix(self.n, self.m, self.cardinality)
 
         # Train LabelModel
         label_model = LabelModel(cardinality=self.cardinality, verbose=False)
@@ -374,6 +373,23 @@ class TestLabelModelAdvanced(unittest.TestCase):
         Y_lm = label_model.predict_proba(L).argmax(axis=1)
         err = np.where(Y != Y_lm, 1, 0).sum() / self.n
         self.assertLess(err, 0.1)
+
+    def test_label_model_basic(self):
+        """Test the LabelModel's estimate of P and Y on a simple synthetic dataset."""
+        P, Y, L = generate_simple_label_matrix(self.n, self.m, self.cardinality)
+        self._test_label_model(P, Y, L)
+
+    def test_label_model_sparse(self):
+        """Test the LabelModel's estimate of P and Y on a sparse synthetic dataset.
+        
+        This tests the common setting where LFs abstain most of the time, which can
+        cause issues for example if parameter clamping set too high (e.g. see Issue
+        #1422).
+        """
+        P, Y, L = generate_simple_label_matrix(
+            self.n, self.m, self.cardinality, abstain_multiplier=1000.0
+        )
+        self._test_label_model(P, Y, L)
 
 
 if __name__ == "__main__":

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -355,7 +355,7 @@ class TestLabelModelAdvanced(unittest.TestCase):
         self.n = 10000  # Number of data points
         self.cardinality = 2  # Number of classes
 
-    def _test_label_model(self, P : np.ndarray, Y : np.ndarray, L : np.ndarray) -> None:
+    def _test_label_model(self, P: np.ndarray, Y: np.ndarray, L: np.ndarray) -> None:
         """Test the LabelModel's estimate of P and Y."""
         np.random.seed(123)
 
@@ -381,7 +381,7 @@ class TestLabelModelAdvanced(unittest.TestCase):
 
     def test_label_model_sparse(self):
         """Test the LabelModel's estimate of P and Y on a sparse synthetic dataset.
-        
+
         This tests the common setting where LFs abstain most of the time, which can
         cause issues for example if parameter clamping set too high (e.g. see Issue
         #1422).


### PR DESCRIPTION
## Description of proposed changes
_High level:_ This change makes the clamping threshold of `LabelModel` parameters a hyperparameter in `train_config`, and sets to a much smaller default value to avoid issues in sparse label setting.

_In more detail:_ The `LabelModel` learns the conditional probabilities of the labeling functions outputting certain labels given certain true (but unobserved or latent) true labels, e.g. `P(\lambda = x | Y = y)`. We also clamp these estimates to some min / max values just to guard against pathological errors... but as one might guess, when `P(\lambda = x | Y = y)` is really small- for example in the common sparse label setting where LFs mostly abstain- then clamping at too high of a minimum value messes everything up- we basically save clamped parameters that say these sparse LFs are equally likely to be wrong versus right! Luckily, this is fixed by changing the clamping parameter, which is now a kwarg in `LabelModel.fit`, and defaults to a much smaller value.

## Related issue(s)
- **Fixes #1422**
- Possibly addresses #1437 (TBD)

## Test plan
- Added a test (marked complex) that successfully (a) replicates the original error in #1422 and (b) solves it.

## Checklist
* [x] I have read the **CONTRIBUTING** document.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
