### PR TITLE
Write complete json log after training

### DIFF
--- a/snorkel/classification/training/loggers/log_manager.py
+++ b/snorkel/classification/training/loggers/log_manager.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from typing import Any, Optional
 
 from snorkel.classification.multitask_classifier import MultitaskClassifier
@@ -131,7 +130,6 @@ class LogManager:
     def close(self, model: MultitaskClassifier) -> MultitaskClassifier:
         """Close the log writer and checkpointer if needed. Reload best model."""
         if self.log_writer is not None:
-            self.log_writer.write_log(os.path.join(self.log_writer.log_dir, "log.json"))
             self.log_writer.close()
         if self.checkpointer is not None:
             self.checkpointer.clear()

--- a/snorkel/classification/training/loggers/log_manager.py
+++ b/snorkel/classification/training/loggers/log_manager.py
@@ -127,12 +127,10 @@ class LogManager:
         self.epoch_count = 0
         self.unit_count = 0
 
-    def close(self, model: MultitaskClassifier) -> MultitaskClassifier:
+    def cleanup(self, model: MultitaskClassifier) -> MultitaskClassifier:
         """Close the log writer and checkpointer if needed. Reload best model."""
         if self.log_writer is not None:
-            # The close method may also include writing a log file to disk, depending
-            # on the LogWriter being used.
-            self.log_writer.close()
+            self.log_writer.cleanup()
         if self.checkpointer is not None:
             self.checkpointer.clear()
             model = self.checkpointer.load_best_model(model)

--- a/snorkel/classification/training/loggers/log_manager.py
+++ b/snorkel/classification/training/loggers/log_manager.py
@@ -130,6 +130,8 @@ class LogManager:
     def close(self, model: MultitaskClassifier) -> MultitaskClassifier:
         """Close the log writer and checkpointer if needed. Reload best model."""
         if self.log_writer is not None:
+            # The close method may also include writing a log file to disk, depending
+            # on the LogWriter being used.
             self.log_writer.close()
         if self.checkpointer is not None:
             self.checkpointer.clear()

--- a/snorkel/classification/training/loggers/log_manager.py
+++ b/snorkel/classification/training/loggers/log_manager.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Any, Optional
 
 from snorkel.classification.multitask_classifier import MultitaskClassifier
@@ -130,6 +131,7 @@ class LogManager:
     def close(self, model: MultitaskClassifier) -> MultitaskClassifier:
         """Close the log writer and checkpointer if needed. Reload best model."""
         if self.log_writer is not None:
+            self.log_writer.write_log(os.path.join(self.log_writer.log_dir, "log.json"))
             self.log_writer.close()
         if self.checkpointer is not None:
             self.checkpointer.clear()

--- a/snorkel/classification/training/loggers/log_writer.py
+++ b/snorkel/classification/training/loggers/log_writer.py
@@ -81,7 +81,7 @@ class LogWriter:
         Parameters
         ----------
         config
-            JSON-compatible config to write to TensorBoard
+            JSON-compatible config to write to file
         config_filename
             Name of file in logging directory to write to
         """

--- a/snorkel/classification/training/loggers/log_writer.py
+++ b/snorkel/classification/training/loggers/log_writer.py
@@ -131,4 +131,4 @@ class LogWriter:
 
     def close(self) -> None:
         """Close writer if necessary."""
-        pass
+        self.write_log("log.json")

--- a/snorkel/classification/training/loggers/log_writer.py
+++ b/snorkel/classification/training/loggers/log_writer.py
@@ -130,5 +130,5 @@ class LogWriter:
             json.dump(dict_to_write, f)
 
     def close(self) -> None:
-        """Close writer if necessary."""
+        """Perform final operations and close writer if necessary."""
         self.write_log("log.json")

--- a/snorkel/classification/training/loggers/log_writer.py
+++ b/snorkel/classification/training/loggers/log_writer.py
@@ -129,6 +129,6 @@ class LogWriter:
         with open(log_path, "w") as f:
             json.dump(dict_to_write, f)
 
-    def close(self) -> None:
+    def cleanup(self) -> None:
         """Perform final operations and close writer if necessary."""
         self.write_log("log.json")

--- a/snorkel/classification/training/loggers/tensorboard_writer.py
+++ b/snorkel/classification/training/loggers/tensorboard_writer.py
@@ -56,6 +56,6 @@ class TensorBoardWriter(LogWriter):
         super().write_config(config, config_filename)
         self.writer.add_text(tag="config", text_string=str(config))
 
-    def close(self) -> None:
+    def cleanup(self) -> None:
         """Close the ``SummaryWriter``."""
         self.writer.close()

--- a/snorkel/classification/training/trainer.py
+++ b/snorkel/classification/training/trainer.py
@@ -244,7 +244,7 @@ class Trainer:
 
                 batches.set_postfix(self.metrics)
 
-        model = self.log_manager.close(model)
+        model = self.log_manager.cleanup(model)
 
     def _check_dataloaders(self, dataloaders: List["DictDataLoader"]) -> None:
         """Validate the dataloader splits."""

--- a/test/classification/training/loggers/test_log_manager.py
+++ b/test/classification/training/loggers/test_log_manager.py
@@ -109,7 +109,7 @@ class TestLogManager(unittest.TestCase):
         self.assertEqual(log_manager.batch_total, 4)
         self.assertEqual(log_manager.epoch_total, 2)
 
-    def test_load_on_close(self) -> None:
+    def test_load_on_cleanup(self) -> None:
         log_manager_config = {"counter_unit": "epochs", "evaluation_freq": 1}
         checkpointer = Checkpointer(**log_manager_config, checkpoint_dir=self.test_dir)
         log_manager = LogManager(
@@ -117,7 +117,7 @@ class TestLogManager(unittest.TestCase):
         )
 
         classifier = MultitaskClassifier([])
-        best_classifier = log_manager.close(classifier)
+        best_classifier = log_manager.cleanup(classifier)
         self.assertEqual(best_classifier, classifier)
 
     def test_bad_unit(self) -> None:

--- a/test/classification/training/loggers/test_log_manager.py
+++ b/test/classification/training/loggers/test_log_manager.py
@@ -3,7 +3,7 @@ import tempfile
 import unittest
 
 from snorkel.classification.multitask_classifier import MultitaskClassifier
-from snorkel.classification.training.loggers import Checkpointer, LogManager, LogWriter
+from snorkel.classification.training.loggers import Checkpointer, LogManager
 
 
 class TestLogManager(unittest.TestCase):
@@ -109,12 +109,11 @@ class TestLogManager(unittest.TestCase):
         self.assertEqual(log_manager.batch_total, 4)
         self.assertEqual(log_manager.epoch_total, 2)
 
-    def test_close(self) -> None:
+    def test_load_on_close(self) -> None:
         log_manager_config = {"counter_unit": "epochs", "evaluation_freq": 1}
-        log_writer = LogWriter()
         checkpointer = Checkpointer(**log_manager_config, checkpoint_dir=self.test_dir)
         log_manager = LogManager(
-            n_batches_per_epoch=2, checkpointer=checkpointer, log_writer=log_writer
+            n_batches_per_epoch=2, checkpointer=checkpointer, log_writer=None
         )
 
         classifier = MultitaskClassifier([])

--- a/test/classification/training/loggers/test_log_writer.py
+++ b/test/classification/training/loggers/test_log_writer.py
@@ -48,7 +48,7 @@ class TestLogWriter(unittest.TestCase):
 
     def test_write_config(self) -> None:
         run_name = "my_run"
-        config = TempConfig(b="bar")
+        config = TempConfig(b="bar")  # type: ignore
         log_writer = LogWriter(run_name=run_name, log_dir=self.test_dir)
         log_writer.write_config(config)
         log_path = os.path.join(self.test_dir, run_name, "config.json")

--- a/test/classification/training/loggers/test_tensorboard_writer.py
+++ b/test/classification/training/loggers/test_tensorboard_writer.py
@@ -32,4 +32,4 @@ class TestTensorBoardWriter(unittest.TestCase):
         with open(log_path, "r") as f:
             file_config = json.load(f)
         self.assertEqual(config._asdict(), file_config)
-        writer.close()
+        writer.cleanup()

--- a/test/classification/training/test_trainer.py
+++ b/test/classification/training/test_trainer.py
@@ -1,4 +1,6 @@
 import copy
+import json
+import os
 import tempfile
 import unittest
 
@@ -141,6 +143,24 @@ class TrainerTest(unittest.TestCase):
                     log_writer_config=log_writer_config,
                 )
                 trainer.fit(model, [dataloaders[0]])
+
+    def test_log_writer_json(self):
+        # Addresses issue #1439
+        # Confirm that a log file is written to the specified location after training
+        run_name = "log.json"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            log_writer_config = {"log_dir": temp_dir, "run_name": run_name}
+            trainer = Trainer(
+                **base_config,
+                logging=True,
+                log_writer="json",
+                log_writer_config=log_writer_config,
+            )
+            trainer.fit(model, [dataloaders[0]])
+            log_path = os.path.join(trainer.log_writer.log_dir, run_name)
+            with open(log_path, "r") as f:
+                log = json.load(f)
+            self.assertIn("model/all/train/loss", log)
 
     def test_optimizer_init(self):
         trainer = Trainer(**base_config, optimizer="sgd")


### PR DESCRIPTION
## Description of proposed changes
As part of closing the `LogManager` at the end of training, write the run log to file.
This appears to have been neglected before because when the log_writer is set to `tensorboard` (the default), the TensorBoard log is written incrementally over the course of training, whereas the json log is written all at once at the end.

## Related issue(s)
Fixes #1439 

## Test plan
New unit test confirms that log is written at the end of training.

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
