### PR TITLE
Fix lf summary no abstain 1446

### DIFF
--- a/snorkel/labeling/analysis.py
+++ b/snorkel/labeling/analysis.py
@@ -354,7 +354,12 @@ class LFAnalysis:
         d["Conflicts"] = Series(data=self.lf_conflicts(), index=lf_names)
 
         if Y is not None:
-            confusions = [confusion_matrix(Y, self.L[:, i])[1:, 1:] for i in range(m)]
+            labels = np.unique(
+                np.concatenate((Y.flatten(), self.L.flatten(), np.array([-1])))
+            )
+            confusions = [
+                confusion_matrix(Y, self.L[:, i], labels)[1:, 1:] for i in range(m)
+            ]
             corrects = [np.diagonal(conf).sum() for conf in confusions]
             incorrects = [
                 conf.sum() - correct for conf, correct in zip(confusions, corrects)

--- a/test/labeling/test_analysis.py
+++ b/test/labeling/test_analysis.py
@@ -16,6 +16,15 @@ L = [
 
 Y = [0, 1, 2, 0, 1, 2]
 
+L_wo_abstain = [
+    [3, 3, 3, 5, 4, 3],
+    [3, 4, 5, 5, 4, 3],
+    [5, 3, 4, 4, 5, 3],
+    [4, 4, 5, 4, 3, 3],
+    [3, 4, 3, 5, 4, 3],
+    [5, 3, 3, 4, 4, 3],
+]
+
 
 def f(x):
     return -1
@@ -24,6 +33,7 @@ def f(x):
 class TestAnalysis(unittest.TestCase):
     def setUp(self) -> None:
         self.lfa = LFAnalysis(np.array(L))
+        self.lfa_wo_abstain = LFAnalysis(np.array(L_wo_abstain))
         self.Y = np.array(Y)
 
     def test_label_coverage(self) -> None:
@@ -130,3 +140,18 @@ class TestAnalysis(unittest.TestCase):
     def test_wrong_number_of_lfs(self) -> None:
         with self.assertRaisesRegex(ValueError, "Number of LFs"):
             LFAnalysis(np.array(L), [LabelingFunction(s, f) for s in "ab"])
+
+    def test_lf_summary_without_abstain(self) -> None:
+        df = self.lfa_wo_abstain.lf_summary(self.Y + 4, est_weights=None)
+        df_expected = pd.DataFrame(
+            {
+                "Polarity": [[3, 4, 5], [3, 4], [3, 4, 5], [4, 5], [3, 4, 5], [3]],
+                "Coverage": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                "Overlaps": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                "Conflicts": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                "Correct": [1, 1, 1, 3, 1, 0],
+                "Incorrect": [5, 5, 5, 3, 5, 6],
+                "Emp. Acc.": [1 / 6, 1 / 6, 1 / 6, 3 / 6, 1 / 6, 0],
+            }
+        )
+        pd.testing.assert_frame_equal(df.round(6), df_expected.round(6))


### PR DESCRIPTION
## Description of proposed changes

Fix the computation of correct/incorrect values from the confusion matrix when the L input data didn't have ABSTAIN label. We only slice the confusion matrix on [1:, 1:] when there is some ABSTAIN label, i.e. -1 values. The full confusion matrix should be taken into account when you don't have -1 values.

## Related issue(s)

Fixes #1446 

## Test plan

## Checklist

Need help on these? Just ask!

* [X] I have read the **CONTRIBUTING** document.
* [ ] I have updated the documentation accordingly.
* [X] I have added tests to cover my changes.
* [x] All new and existing tests passed.

I've some trouble with pyspark for the test part. But I think it's not related with this fix.
