### PR TITLE
Ignore abstains in Scorer, change LabelModel default tie break policy

### DIFF
--- a/snorkel/analysis/scorer.py
+++ b/snorkel/analysis/scorer.py
@@ -49,7 +49,7 @@ class Scorer:
                 if metric not in METRICS:
                     raise ValueError(f"Unrecognized metric: {metric}")
 
-            filter_dict = {} if abstain_label is None else {"golds": [abstain_label]}
+            filter_dict = {} if abstain_label is None else {"golds": [abstain_label], "preds": [abstain_label]}
             self.metrics = {
                 m: partial(metric_score, metric=m, filter_dict=filter_dict)
                 for m in metrics

--- a/snorkel/analysis/scorer.py
+++ b/snorkel/analysis/scorer.py
@@ -49,7 +49,11 @@ class Scorer:
                 if metric not in METRICS:
                     raise ValueError(f"Unrecognized metric: {metric}")
 
-            filter_dict = {} if abstain_label is None else {"golds": [abstain_label], "preds": [abstain_label]}
+            filter_dict = (
+                {}
+                if abstain_label is None
+                else {"golds": [abstain_label], "preds": [abstain_label]}
+            )
             self.metrics = {
                 m: partial(metric_score, metric=m, filter_dict=filter_dict)
                 for m in metrics

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -477,8 +477,10 @@ class LabelModel(nn.Module):
         >>> label_model.score(L, Y=np.array([1, 1, 1]), metrics=["f1"])
         {'f1': 0.8}
         """
-        if tie_break_policy == 'abstain':
-            logging.warning(f"Metrics calculated over datapoints with non-abstain labels only")
+        if tie_break_policy == "abstain":
+            logging.warning(
+                f"Metrics calculated over datapoints with non-abstain labels only"
+            )
 
         Y_pred, Y_prob = self.predict(
             L, return_probs=True, tie_break_policy=tie_break_policy

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -455,7 +455,7 @@ class LabelModel(nn.Module):
         L
             An [n,m] matrix with values in {-1,0,1,...,k-1}
         Y
-            Gold labels associated with datapoints in L
+            Gold labels associated with data points in L
         metrics
             A list of metric names
         tie_break_policy
@@ -479,7 +479,7 @@ class LabelModel(nn.Module):
         """
         if tie_break_policy == "abstain":  # pragma: no cover
             logging.warning(
-                "Metrics calculated over datapoints with non-abstain labels only"
+                "Metrics calculated over data points with non-abstain labels only"
             )
 
         Y_pred, Y_prob = self.predict(

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -477,9 +477,9 @@ class LabelModel(nn.Module):
         >>> label_model.score(L, Y=np.array([1, 1, 1]), metrics=["f1"])
         {'f1': 0.8}
         """
-        if tie_break_policy == "abstain":
+        if tie_break_policy == "abstain":  # pragma: no cover
             logging.warning(
-                f"Metrics calculated over datapoints with non-abstain labels only"
+                "Metrics calculated over datapoints with non-abstain labels only"
             )
 
         Y_pred, Y_prob = self.predict(

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -396,7 +396,7 @@ class LabelModel(nn.Module):
         self,
         L: np.ndarray,
         return_probs: Optional[bool] = False,
-        tie_break_policy: str = "random",
+        tie_break_policy: str = "abstain",
     ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
         """Return predicted labels, with ties broken according to policy.
 
@@ -446,7 +446,7 @@ class LabelModel(nn.Module):
         L: np.ndarray,
         Y: np.ndarray,
         metrics: Optional[List[str]] = ["accuracy"],
-        tie_break_policy: str = "random",
+        tie_break_policy: str = "abstain",
     ) -> Dict[str, float]:
         """Calculate one or more scores from user-specified and/or user-defined metrics.
 
@@ -477,6 +477,9 @@ class LabelModel(nn.Module):
         >>> label_model.score(L, Y=np.array([1, 1, 1]), metrics=["f1"])
         {'f1': 0.8}
         """
+        if tie_break_policy == 'abstain':
+            logging.warning(f"Metrics calculated over datapoints with non-abstain labels only")
+
         Y_pred, Y_prob = self.predict(
             L, return_probs=True, tie_break_policy=tie_break_policy
         )

--- a/test/analysis/test_scorer.py
+++ b/test/analysis/test_scorer.py
@@ -68,10 +68,17 @@ class ScorerTest(unittest.TestCase):
         results_expected = dict(accuracy=0.6)
         self.assertEqual(results, results_expected)
 
-        # Test abstain=-1
+        # Test abstain=-1 for gold
         scorer = Scorer(metrics=["accuracy"], abstain_label=-1)
         results = scorer.score(golds, preds, probs)
         results_expected = dict(accuracy=0.75)
+        self.assertEqual(results, results_expected)
+
+        # Test abstain=-1 for preds and gold
+        abstain_preds = np.array([-1, -1, 1, 1, 0])
+        abstain_probs = np.array([0.5, 0.5, 0.9, 0.7, 0.4])
+        results = scorer.score(golds, abstain_preds, abstain_probs)
+        results_expected = dict(accuracy=0.5)
         self.assertEqual(results, results_expected)
 
         # Test abstain set to different value

--- a/test/analysis/test_scorer.py
+++ b/test/analysis/test_scorer.py
@@ -76,8 +76,7 @@ class ScorerTest(unittest.TestCase):
 
         # Test abstain=-1 for preds and gold
         abstain_preds = np.array([-1, -1, 1, 1, 0])
-        abstain_probs = np.array([0.5, 0.5, 0.9, 0.7, 0.4])
-        results = scorer.score(golds, abstain_preds, abstain_probs)
+        results = scorer.score(golds, abstain_preds)
         results_expected = dict(accuracy=0.5)
         self.assertEqual(results, results_expected)
 

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -240,6 +240,7 @@ class LabelModelTest(unittest.TestCase):
         np.testing.assert_array_almost_equal(probs, true_probs)
 
     def test_predict(self):
+        # 3 LFs that always disagree/abstain leads to all abstains
         L = np.array([[-1, 1, 0], [0, -1, 1], [1, 0, -1]])
         label_model = LabelModel(cardinality=2, verbose=False)
         label_model.fit(L, n_epochs=100)

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -243,7 +243,9 @@ class LabelModelTest(unittest.TestCase):
         L = np.array([[-1, 1, 0], [0, -1, 1], [1, 0, -1]])
         label_model = LabelModel(cardinality=2, verbose=False)
         label_model.fit(L, n_epochs=100)
-        np.testing.assert_array_almost_equal(label_model.predict(L), np.array([-1, -1, -1]))
+        np.testing.assert_array_almost_equal(
+            label_model.predict(L), np.array([-1, -1, -1])
+        )
 
         L = np.array([[0, 1, 0], [0, 1, 0]])
         label_model = self._set_up_model(L)
@@ -264,7 +266,9 @@ class LabelModelTest(unittest.TestCase):
         label_model = LabelModel(cardinality=2, verbose=False)
         label_model.fit(L, n_epochs=100)
         results = label_model.score(L, Y)
-        np.testing.assert_array_almost_equal(label_model.predict(L), np.array([1, -1, 1]))
+        np.testing.assert_array_almost_equal(
+            label_model.predict(L), np.array([1, -1, 1])
+        )
 
         results_expected = dict(accuracy=1.0)
         self.assertEqual(results, results_expected)

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -240,6 +240,11 @@ class LabelModelTest(unittest.TestCase):
         np.testing.assert_array_almost_equal(probs, true_probs)
 
     def test_predict(self):
+        L = np.array([[-1, 1, 0], [0, -1, 1], [1, 0, -1]])
+        label_model = LabelModel(cardinality=2, verbose=False)
+        label_model.fit(L, n_epochs=100)
+        np.testing.assert_array_almost_equal(label_model.predict(L), np.array([-1, -1, -1]))
+
         L = np.array([[0, 1, 0], [0, 1, 0]])
         label_model = self._set_up_model(L)
 
@@ -254,6 +259,16 @@ class LabelModelTest(unittest.TestCase):
         np.testing.assert_array_almost_equal(probs, true_probs)
 
     def test_score(self):
+        L = np.array([[1, 1, 0], [-1, -1, -1], [1, 0, 1]])
+        Y = np.array([1, 0, 1])
+        label_model = LabelModel(cardinality=2, verbose=False)
+        label_model.fit(L, n_epochs=100)
+        results = label_model.score(L, Y)
+        np.testing.assert_array_almost_equal(label_model.predict(L), np.array([1, -1, 1]))
+
+        results_expected = dict(accuracy=1.0)
+        self.assertEqual(results, results_expected)
+
         L = np.array([[1, 0, 1], [1, 0, 1]])
         label_model = self._set_up_model(L)
         label_model.mu = nn.Parameter(label_model.mu_init.clone().clamp(0.01, 0.99))


### PR DESCRIPTION
## Description of proposed changes
- Change Scorer default to ignore abstains in preds
- Change LabelModel tie break policy default to abstain (instead of random)
- Log warning when calling LabelModel `score()` function

## Test plan
- Add tests in LabelModel for `predict()` and `score()` functions related to abstain default
- Add test for Scorer to check abstains ignored in preds by default

## Checklist
* [x] I have read the **CONTRIBUTING** document.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.