### PR TITLE
Explicit seed setting

### DIFF
--- a/docs/packages/utils.rst
+++ b/docs/packages/utils.rst
@@ -12,5 +12,4 @@ General machine learning utilities shared across Snorkel.
    filter_labels
    preds_to_probs
    probs_to_preds
-   set_seed
    to_int_label_array

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -1,4 +1,5 @@
 import logging
+import random
 from collections import Counter
 from itertools import chain, permutations
 from typing import Any, Dict, List, NamedTuple, Optional, Set, Tuple, Union
@@ -13,7 +14,7 @@ from snorkel.labeling.analysis import LFAnalysis
 from snorkel.labeling.model.graph_utils import get_clique_tree
 from snorkel.labeling.model.logger import Logger
 from snorkel.types import Config
-from snorkel.utils import probs_to_preds, set_seed
+from snorkel.utils import probs_to_preds
 from snorkel.utils.config_utils import merge_config
 from snorkel.utils.lr_schedulers import LRSchedulerConfig
 from snorkel.utils.optimizers import OptimizerConfig
@@ -841,7 +842,9 @@ class LabelModel(nn.Module):
             TrainConfig(), kwargs  # type:ignore
         )
         # Update base config so that it includes all parameters
-        set_seed(self.train_config.seed)
+        random.seed(self.train_config.seed)
+        np.random.seed(self.train_config.seed)
+        torch.manual_seed(self.train_config.seed)
 
         L_shift = L_train + 1  # convert to {0, 1, ..., k}
         if L_shift.max() > self.cardinality:

--- a/snorkel/utils/__init__.py
+++ b/snorkel/utils/__init__.py
@@ -4,6 +4,5 @@ from .core import (  # noqa: F401
     filter_labels,
     preds_to_probs,
     probs_to_preds,
-    set_seed,
     to_int_label_array,
 )

--- a/snorkel/utils/core.py
+++ b/snorkel/utils/core.py
@@ -1,16 +1,7 @@
 import hashlib
-import random
 from typing import Dict, List
 
 import numpy as np
-import torch
-
-
-def set_seed(seed: int) -> None:
-    """Set the Python, NumPy, and PyTorch random seeds."""
-    random.seed(seed)
-    np.random.seed(seed)
-    torch.manual_seed(seed)
 
 
 def _hash(i: int) -> int:

--- a/test/classification/test_classifier_convergence.py
+++ b/test/classification/test_classifier_convergence.py
@@ -1,3 +1,4 @@
+import random
 import unittest
 from typing import List
 
@@ -16,7 +17,6 @@ from snorkel.classification import (
     Task,
     Trainer,
 )
-from snorkel.utils import set_seed
 
 N_TRAIN = 1000
 N_VALID = 300
@@ -26,7 +26,9 @@ class ClassifierConvergenceTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Ensure deterministic runs
-        set_seed(123)
+        random.seed(123)
+        np.random.seed(123)
+        torch.manual_seed(123)
 
     @pytest.mark.complex
     def test_convergence(self):

--- a/test/classification/test_multitask_classifier.py
+++ b/test/classification/test_multitask_classifier.py
@@ -1,4 +1,5 @@
 import os
+import random
 import tempfile
 import unittest
 
@@ -14,7 +15,6 @@ from snorkel.classification import (
     Operation,
     Task,
 )
-from snorkel.utils import set_seed
 
 NUM_EXAMPLES = 10
 BATCH_SIZE = 2
@@ -28,7 +28,9 @@ class ClassifierTest(unittest.TestCase):
         cls.dataloader = create_dataloader("task1")
 
     def setUp(self):
-        set_seed(123)
+        random.seed(123)
+        np.random.seed(123)
+        torch.manual_seed(123)
 
     def test_onetask_model(self):
         model = MultitaskClassifier(tasks=[self.task1])

--- a/test/classification/training/schedulers/test_schedulers.py
+++ b/test/classification/training/schedulers/test_schedulers.py
@@ -1,5 +1,7 @@
+import random
 import unittest
 
+import numpy as np
 import torch
 
 from snorkel.classification import DictDataLoader, DictDataset
@@ -7,7 +9,6 @@ from snorkel.classification.training.schedulers import (
     SequentialScheduler,
     ShuffledScheduler,
 )
-from snorkel.utils import set_seed
 
 dataset1 = DictDataset(
     "d1",
@@ -37,7 +38,9 @@ class SequentialTest(unittest.TestCase):
         self.assertEqual(data, sorted(data))
 
     def test_shuffled(self):
-        set_seed(123)
+        random.seed(123)
+        np.random.seed(123)
+        torch.manual_seed(123)
         scheduler = ShuffledScheduler()
         data = []
         for (batch, dl) in scheduler.get_batches(dataloaders):

--- a/test/labeling/test_convergence.py
+++ b/test/labeling/test_convergence.py
@@ -1,8 +1,10 @@
+import random
 import unittest
 
 import numpy as np
 import pandas as pd
 import pytest
+import torch
 
 from snorkel.labeling import (
     LabelingFunction,
@@ -12,7 +14,6 @@ from snorkel.labeling import (
 )
 from snorkel.preprocess import preprocessor
 from snorkel.types import DataPoint
-from snorkel.utils import set_seed
 
 
 def create_data(n: int) -> pd.DataFrame:
@@ -61,7 +62,9 @@ class LabelingConvergenceTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Ensure deterministic runs
-        set_seed(123)
+        random.seed(123)
+        np.random.seed(123)
+        torch.manual_seed(123)
 
         # Create raw data
         cls.N_TRAIN = 1500

--- a/test/slicing/test_convergence.py
+++ b/test/slicing/test_convergence.py
@@ -1,3 +1,4 @@
+import random
 import unittest
 from typing import List
 
@@ -23,7 +24,6 @@ from snorkel.slicing import (
     slicing_function,
 )
 from snorkel.types import DataPoint
-from snorkel.utils import set_seed
 
 
 # Define SFs specifying points inside a circle
@@ -55,7 +55,9 @@ class SlicingConvergenceTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Ensure deterministic runs
-        set_seed(123)
+        random.seed(123)
+        np.random.seed(123)
+        torch.manual_seed(123)
 
         # Create raw data
         cls.N_TRAIN = 1500

--- a/test/slicing/test_slice_combiner.py
+++ b/test/slicing/test_slice_combiner.py
@@ -1,16 +1,18 @@
 import random
 import unittest
 
+import numpy as np
 import torch
 
 from snorkel.slicing import SliceCombinerModule
-from snorkel.utils import set_seed
 
 
 class SliceCombinerTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        set_seed(123)
+        random.seed(123)
+        np.random.seed(123)
+        torch.manual_seed(123)
 
     def test_forward_shape(self):
         """Test that the reweight representation shape matches expected feature size."""


### PR DESCRIPTION
## Description of proposed changes

Move to setting seeds explicitly. Ambiguous `set_seed` has caused a few issues, and this reduces our dependency on PyTorch.

## Test plan

Updated unit tests, all passing.

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [x] All new and existing tests passed.
