### PR TITLE
Saving all attributes of LabelModel

### DIFF
--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -930,15 +930,13 @@ class LabelModel(nn.Module):
         if self.config.verbose:  # pragma: no cover
             logging.info("Finished Training")
 
-    def save(self, destination: str, **kwargs: Any) -> None:
+    def save(self, destination: str) -> None:
         """Save label model.
 
         Parameters
         ----------
         destination
-            File location for saving model
-        **kwargs
-            Arguments for torch.save
+            Filename for saving model
 
         Example
         -------
@@ -948,20 +946,13 @@ class LabelModel(nn.Module):
         pickle.dump(self.__dict__, f)
         f.close()
 
-    def load(self, source: str, **kwargs: Any) -> Any:
+    def load(self, source: str) -> None:
         """Load existing label model.
 
         Parameters
         ----------
         source
-            File location from where to load model
-        **kwargs
-            Arguments for torch.load
-
-        Returns
-        -------
-        LabelModel
-            LabelModel with appropriate loaded parameters
+            Filename to load model from
 
         Example
         -------

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -1,4 +1,5 @@
 import logging
+import pickle
 import random
 from collections import Counter
 from itertools import chain, permutations
@@ -364,7 +365,7 @@ class LabelModel(nn.Module):
         Parameters
         ----------
         L
-            An [n,m] matrix with values in {-1,0,1,...,k-1}
+            An [n,m] matrix with values in {-1,0,1,...,k-1}f
 
         Returns
         -------
@@ -941,13 +942,13 @@ class LabelModel(nn.Module):
 
         Example
         -------
-        >>> label_model.save('./saved_label_model')  # doctest: +SKIP
+        >>> label_model.save('./saved_label_model.pkl')  # doctest: +SKIP
         """
-        with open(destination, "wb") as f:
-            torch.save(self, f, **kwargs)
+        f = open(destination, "wb")
+        pickle.dump(self.__dict__, f)
+        f.close()
 
-    @staticmethod
-    def load(source: str, **kwargs: Any) -> Any:
+    def load(self, source: str, **kwargs: Any) -> Any:
         """Load existing label model.
 
         Parameters
@@ -966,7 +967,9 @@ class LabelModel(nn.Module):
         -------
         Load parameters saved in ``saved_label_model``
 
-        >>> label_model.load('./saved_label_model')  # doctest: +SKIP
+        >>> label_model.load('./saved_label_model.pkl')  # doctest: +SKIP
         """
-        with open(source, "rb") as f:
-            return torch.load(f, **kwargs)
+        f = open(source, "rb")
+        tmp_dict = pickle.load(f)
+        f.close()
+        self.__dict__.update(tmp_dict)

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -336,14 +336,21 @@ class LabelModelTest(unittest.TestCase):
             label_model.fit(L, n_epochs=1, lr_scheduler="bad_scheduler")
 
     def test_save_and_load(self):
-        L = np.array([[0, -1, 0], [0, 1, 0]])
+        L = np.array([[0, -1, 0], [0, 1, 1]])
         label_model = LabelModel(cardinality=2, verbose=False)
         label_model.fit(L, n_epochs=1)
+        original_preds = label_model.predict(L)
+
         dir_path = tempfile.mkdtemp()
-        save_path = dir_path + "label_model"
+        save_path = dir_path + "label_model.pkl"
         label_model.save(save_path)
-        label_model.load(save_path)
+
+        label_model_new = LabelModel(cardinality=2, verbose=False)
+        label_model_new.load(save_path)
+        loaded_preds = label_model_new.predict(L)
         shutil.rmtree(dir_path)
+
+        np.testing.assert_array_equal(loaded_preds, original_preds)
 
     def test_optimizer_init(self):
         L = np.array([[0, -1, 0], [0, 1, 0]])


### PR DESCRIPTION
## Description of proposed changes
Saving and loading LabelModel via attribute `__dict__` pickling. This saves out parameters other than weights like `mu` that are needed to methods like `predict()` without having to call `fit()` with the loaded model

## Related issue(s)

Fixes #1460 

## Test plan
Edited test for `save()` and `load()` to check predictions are the same for saved and loaded model

## Checklist
* [x] I have read the **CONTRIBUTING** document.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [x] All new and existing tests passed.