### PR TITLE
Option to run LabelModel on GPU

### DIFF
--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -337,7 +337,7 @@ class LabelModel(nn.Module):
         np.ndarray
             An [m, k + 1, k] np.ndarray conditional probabilities table.
         """
-        return self._get_conditional_probs(self.mu.clone().cpu().detach().numpy())
+        return self._get_conditional_probs(self.mu.cpu().detach().numpy())
 
     def get_weights(self) -> np.ndarray:
         """Return the vector of learned LF weights for combining LFs.
@@ -758,7 +758,7 @@ class LabelModel(nn.Module):
         int
             Number of LFs better than random
         """
-        P = self.P.clone().cpu().detach().numpy()
+        P = self.P.cpu().detach().numpy()
         cprobs = self._get_conditional_probs(mu)
         count = 0
         for i in range(self.m):

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -238,7 +238,9 @@ class LabelModel(nn.Module):
         """
         L_aug = self._get_augmented_label_matrix(L, higher_order=higher_order)
         self.d = L_aug.shape[1]
-        self.O = torch.from_numpy(L_aug.T @ L_aug / self.n).float().to(self.config.device)
+        self.O = (
+            torch.from_numpy(L_aug.T @ L_aug / self.n).float().to(self.config.device)
+        )
 
     def _init_params(self) -> None:
         r"""Initialize the learned params.
@@ -805,7 +807,9 @@ class LabelModel(nn.Module):
                 scores.append(-1)
 
         # Set mu according to highest-scoring permutation
-        self.mu = nn.Parameter(torch.Tensor(mu @ Zs[np.argmax(scores)]).to(self.config.device))  # type: ignore
+        self.mu = nn.Parameter(
+            torch.Tensor(mu @ Zs[np.argmax(scores)]).to(self.config.device) # type: ignore
+        )
 
     def fit(
         self,

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -808,7 +808,9 @@ class LabelModel(nn.Module):
 
         # Set mu according to highest-scoring permutation
         self.mu = nn.Parameter(
-            torch.Tensor(mu @ Zs[np.argmax(scores)]).to(self.config.device) # type: ignore
+            torch.Tensor(mu @ Zs[np.argmax(scores)]).to(  # type: ignore
+                self.config.device
+            )
         )
 
     def fit(

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -95,7 +95,7 @@ class LabelModelTest(unittest.TestCase):
                 [1 / 4, 0, 0, 1 / 4, 0, 1 / 4],
             ]
         )
-        np.testing.assert_array_almost_equal(label_model.O.numpy(), true_O)
+        np.testing.assert_array_almost_equal(label_model.O.cpu().detach().numpy(), true_O)
 
         label_model = self._set_up_model(L)
         label_model._generate_O(L + 1, higher_order=False)
@@ -109,12 +109,12 @@ class LabelModelTest(unittest.TestCase):
                 [1 / 4, 0, 0, 1 / 4, 0, 1 / 4],
             ]
         )
-        np.testing.assert_array_almost_equal(label_model.O.numpy(), true_O)
+        np.testing.assert_array_almost_equal(label_model.O.cpu().detach().numpy(), true_O)
 
         # Higher order returns same matrix (num source = num cliques)
         # Need to test c_tree form
         label_model._generate_O(L + 1, higher_order=True)
-        np.testing.assert_array_almost_equal(label_model.O.numpy(), true_O)
+        np.testing.assert_array_almost_equal(label_model.O.cpu().detach().numpy(), true_O)
 
     def test_augmented_L_construction(self):
         # 5 LFs
@@ -288,9 +288,8 @@ class LabelModelTest(unittest.TestCase):
 
     def test_loss(self):
         L = np.array([[0, -1, 0], [0, 1, -1]])
-        label_model = self._set_up_model(L)
-        label_model._get_augmented_label_matrix(L + 1, higher_order=True)
-
+        label_model = LabelModel(cardinality=2, verbose=False)
+        label_model.fit(L, n_epochs=1)
         label_model.mu = nn.Parameter(label_model.mu_init.clone() + 0.05)
 
         # l2_loss = l2*M*K*||mu - mu_init||_2 = 3*2*(0.05^2) = 0.03

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -95,7 +95,9 @@ class LabelModelTest(unittest.TestCase):
                 [1 / 4, 0, 0, 1 / 4, 0, 1 / 4],
             ]
         )
-        np.testing.assert_array_almost_equal(label_model.O.cpu().detach().numpy(), true_O)
+        np.testing.assert_array_almost_equal(
+            label_model.O.cpu().detach().numpy(), true_O
+        )
 
         label_model = self._set_up_model(L)
         label_model._generate_O(L + 1, higher_order=False)
@@ -109,12 +111,16 @@ class LabelModelTest(unittest.TestCase):
                 [1 / 4, 0, 0, 1 / 4, 0, 1 / 4],
             ]
         )
-        np.testing.assert_array_almost_equal(label_model.O.cpu().detach().numpy(), true_O)
+        np.testing.assert_array_almost_equal(
+            label_model.O.cpu().detach().numpy(), true_O
+        )
 
         # Higher order returns same matrix (num source = num cliques)
         # Need to test c_tree form
         label_model._generate_O(L + 1, higher_order=True)
-        np.testing.assert_array_almost_equal(label_model.O.cpu().detach().numpy(), true_O)
+        np.testing.assert_array_almost_equal(
+            label_model.O.cpu().detach().numpy(), true_O
+        )
 
     def test_augmented_L_construction(self):
         # 5 LFs


### PR DESCRIPTION
## Description of proposed changes
Fixed some parameter definitions to allow LabelModel to run on GPU.

## Related issue(s)
Fixes #1430 

## Test plan
- Edited existing tests to work with change in parameter definition
- No new tests added. Tested locally by adding `device='cuda'` for LabelModel tests.

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [x] All new and existing tests passed.