### PR TITLE
Do not ignore abstains when calculating coverage

### DIFF
--- a/snorkel/analysis/scorer.py
+++ b/snorkel/analysis/scorer.py
@@ -55,9 +55,13 @@ class Scorer:
                     if abstain_label is None or metric == "coverage"
                     else {"golds": [abstain_label], "preds": [abstain_label]}
                 )
-                self.metrics.update({
-                    metric: partial(metric_score, metric=metric, filter_dict=filter_dict)
-                })
+                self.metrics.update(
+                    {
+                        metric: partial(
+                            metric_score, metric=metric, filter_dict=filter_dict
+                        )
+                    }
+                )
 
         if custom_metric_funcs is not None:
             self.metrics.update(custom_metric_funcs)

--- a/snorkel/analysis/scorer.py
+++ b/snorkel/analysis/scorer.py
@@ -44,22 +44,20 @@ class Scorer:
     ) -> None:
 
         self.metrics: Dict[str, Callable[..., float]]
+        self.metrics = {}
         if metrics:
             for metric in metrics:
                 if metric not in METRICS:
                     raise ValueError(f"Unrecognized metric: {metric}")
 
-            filter_dict = (
-                {}
-                if abstain_label is None
-                else {"golds": [abstain_label], "preds": [abstain_label]}
-            )
-            self.metrics = {
-                m: partial(metric_score, metric=m, filter_dict=filter_dict)
-                for m in metrics
-            }
-        else:
-            self.metrics = {}
+                filter_dict = (
+                    {}
+                    if abstain_label is None or metric == "coverage"
+                    else {"golds": [abstain_label], "preds": [abstain_label]}
+                )
+                self.metrics.update({
+                    metric: partial(metric_score, metric=metric, filter_dict=filter_dict)
+                })
 
         if custom_metric_funcs is not None:
             self.metrics.update(custom_metric_funcs)

--- a/test/analysis/test_scorer.py
+++ b/test/analysis/test_scorer.py
@@ -80,6 +80,11 @@ class ScorerTest(unittest.TestCase):
         results_expected = dict(accuracy=0.5)
         self.assertEqual(results, results_expected)
 
+        scorer = Scorer(metrics=["coverage"], abstain_label=-1)
+        results = scorer.score(golds, abstain_preds)
+        results_expected = dict(coverage=0.6)
+        self.assertEqual(results, results_expected)
+
         # Test abstain set to different value
         scorer = Scorer(metrics=["accuracy"], abstain_label=10)
         results = scorer.score(golds, preds, probs)

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -272,12 +272,12 @@ class LabelModelTest(unittest.TestCase):
         Y = np.array([1, 0, 1])
         label_model = LabelModel(cardinality=2, verbose=False)
         label_model.fit(L, n_epochs=100)
-        results = label_model.score(L, Y)
+        results = label_model.score(L, Y, metrics=["accuracy", "coverage"])
         np.testing.assert_array_almost_equal(
             label_model.predict(L), np.array([1, -1, 1])
         )
 
-        results_expected = dict(accuracy=1.0)
+        results_expected = dict(accuracy=1.0, coverage=2 / 3)
         self.assertEqual(results, results_expected)
 
         L = np.array([[1, 0, 1], [1, 0, 1]])


### PR DESCRIPTION
## Description of proposed changes
Ignore abstains (-1) for performance metrics *other than coverage*

## Test plan
- Add tests for Scorer and LabelModel to test correct behavior

## Checklist
* [x] I have read the **CONTRIBUTING** document.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [x] All new and existing tests passed.