### PR TITLE
Add fault tolerance to appliers

### DIFF
--- a/snorkel/labeling/apply/spark.py
+++ b/snorkel/labeling/apply/spark.py
@@ -5,7 +5,7 @@ from pyspark import RDD
 
 from snorkel.types import DataPoint
 
-from .core import BaseLFApplier, RowData, apply_lfs_to_data_point
+from .core import BaseLFApplier, RowData, _FunctionCaller, apply_lfs_to_data_point
 
 
 class SparkLFApplier(BaseLFApplier):
@@ -18,22 +18,25 @@ class SparkLFApplier(BaseLFApplier):
     ``test/labeling/apply/lf_applier_spark_test_script.py``.
     """
 
-    def apply(self, data_points: RDD) -> np.ndarray:
+    def apply(self, data_points: RDD, fault_tolerant: bool = False) -> np.ndarray:
         """Label PySpark RDD of data points with LFs.
 
         Parameters
         ----------
         data_points
             PySpark RDD containing data points to be labeled by LFs
+        fault_tolerant
+            Output ``-1`` if LF execution fails?
 
         Returns
         -------
         np.ndarray
             Matrix of labels emitted by LFs
         """
+        f_caller = _FunctionCaller(fault_tolerant)
 
         def map_fn(args: Tuple[DataPoint, int]) -> RowData:
-            return apply_lfs_to_data_point(*args, lfs=self._lfs)
+            return apply_lfs_to_data_point(*args, lfs=self._lfs, f_caller=f_caller)
 
         labels = data_points.zipWithIndex().map(map_fn).collect()
         return self._numpy_from_row_data(labels)

--- a/snorkel/slicing/monitor.py
+++ b/snorkel/slicing/monitor.py
@@ -27,5 +27,5 @@ def slice_dataframe(
     S = PandasSFApplier([slicing_function]).apply(df)
 
     # Index into the SF labels by name
-    df_idx = np.where(S[slicing_function.name])[0]
+    df_idx = np.where(S[slicing_function.name])[0]  # type: ignore
     return df.iloc[df_idx]


### PR DESCRIPTION
## Description of proposed changes

Adds fault tolerance to appliers. Allows LFs/SFs to fail (abstaining if they do) and records the number of failures for each LF/SF.

**Note:** we don't track failure metadata for Dask or PySpark in this PR, since merging across processes can be tricky. We can add later if requested.

## Test plan

Added new unit tests for core, Pandas, Dask, and PySpark appliers. Ran `tox -e spark` and `tox -e complex`
