### PR TITLE
Remove fault tolerant mode from LF/SF

### DIFF
--- a/snorkel/labeling/apply/spark.py
+++ b/snorkel/labeling/apply/spark.py
@@ -5,7 +5,7 @@ from pyspark import RDD
 
 from snorkel.types import DataPoint
 
-from .core import BaseLFApplier, RowData, apply_lfs_to_data_point
+from .core import BaseLFApplier, RowData, _FunctionCaller, apply_lfs_to_data_point
 
 
 class SparkLFApplier(BaseLFApplier):
@@ -18,22 +18,25 @@ class SparkLFApplier(BaseLFApplier):
     ``test/labeling/apply/lf_applier_spark_test_script.py``.
     """
 
-    def apply(self, data_points: RDD) -> np.ndarray:
+    def apply(self, data_points: RDD, fault_tolerant: bool = False) -> np.ndarray:
         """Label PySpark RDD of data points with LFs.
 
         Parameters
         ----------
         data_points
             PySpark RDD containing data points to be labeled by LFs
+        fault_tolerant
+            Output ``-1`` if LF execution fails?
 
         Returns
         -------
         np.ndarray
             Matrix of labels emitted by LFs
         """
+        f_caller = _FunctionCaller(fault_tolerant)
 
         def map_fn(args: Tuple[DataPoint, int]) -> RowData:
-            return apply_lfs_to_data_point(*args, lfs=self._lfs)
+            return apply_lfs_to_data_point(*args, lfs=self._lfs, f_caller=f_caller)
 
         labels = data_points.zipWithIndex().map(map_fn).collect()
         return self._numpy_from_row_data(labels)

--- a/snorkel/labeling/lf/nlp.py
+++ b/snorkel/labeling/lf/nlp.py
@@ -73,7 +73,6 @@ class BaseNLPLabelingFunction(LabelingFunction):
         f: Callable[..., int],
         resources: Optional[Mapping[str, Any]] = None,
         pre: Optional[List[BasePreprocessor]] = None,
-        fault_tolerant: bool = False,
         text_field: str = "text",
         doc_field: str = "doc",
         language: str = EN_CORE_WEB_SM,
@@ -83,13 +82,7 @@ class BaseNLPLabelingFunction(LabelingFunction):
         self._create_or_check_preprocessor(
             text_field, doc_field, language, disable, pre or [], memoize
         )
-        super().__init__(
-            name,
-            f,
-            resources=resources,
-            pre=[self._nlp_config.nlp],
-            fault_tolerant=fault_tolerant,
-        )
+        super().__init__(name, f, resources=resources, pre=[self._nlp_config.nlp])
 
 
 class NLPLabelingFunction(BaseNLPLabelingFunction):
@@ -123,8 +116,6 @@ class NLPLabelingFunction(BaseNLPLabelingFunction):
         Labeling resources passed in to ``f`` via ``kwargs``
     pre
         Preprocessors to run before SpacyPreprocessor is executed
-    fault_tolerant
-        Output -1 if LF execution fails?
     text_field
         Name of data point text field to input
     doc_field
@@ -161,8 +152,6 @@ class NLPLabelingFunction(BaseNLPLabelingFunction):
     ----------
     name
         See above
-    fault_tolerant
-        See above
     """
 
     @classmethod
@@ -182,14 +171,13 @@ class base_nlp_labeling_function(labeling_function):
         name: Optional[str] = None,
         resources: Optional[Mapping[str, Any]] = None,
         pre: Optional[List[BasePreprocessor]] = None,
-        fault_tolerant: bool = False,
         text_field: str = "text",
         doc_field: str = "doc",
         language: str = EN_CORE_WEB_SM,
         disable: Optional[List[str]] = None,
         memoize: bool = True,
     ) -> None:
-        super().__init__(name, resources, pre, fault_tolerant)
+        super().__init__(name, resources, pre)
         self.text_field = text_field
         self.doc_field = doc_field
         self.language = language
@@ -217,7 +205,6 @@ class base_nlp_labeling_function(labeling_function):
             f=f,
             resources=self.resources,
             pre=self.pre,
-            fault_tolerant=self.fault_tolerant,
             text_field=self.text_field,
             doc_field=self.doc_field,
             language=self.language,
@@ -237,8 +224,6 @@ class nlp_labeling_function(base_nlp_labeling_function):
         Labeling resources passed in to ``f`` via ``kwargs``
     pre
         Preprocessors to run before SpacyPreprocessor is executed
-    fault_tolerant
-        Output -1 if LF execution fails?
     text_field
         Name of data point text field to input
     doc_field

--- a/snorkel/labeling/lf/nlp_spark.py
+++ b/snorkel/labeling/lf/nlp_spark.py
@@ -24,8 +24,6 @@ class SparkNLPLabelingFunction(BaseNLPLabelingFunction):
         Labeling resources passed in to ``f`` via ``kwargs``
     pre
         Preprocessors to run before SpacyPreprocessor is executed
-    fault_tolerant
-        Output -1 if LF execution fails?
     text_field
         Name of data point text field to input
     doc_field
@@ -47,8 +45,6 @@ class SparkNLPLabelingFunction(BaseNLPLabelingFunction):
     Attributes
     ----------
     name
-        See above
-    fault_tolerant
         See above
     """
 
@@ -72,8 +68,6 @@ class spark_nlp_labeling_function(base_nlp_labeling_function):
         Labeling resources passed in to ``f`` via ``kwargs``
     pre
         Preprocessors to run before SpacyPreprocessor is executed
-    fault_tolerant
-        Output -1 if LF execution fails?
     text_field
         Name of data point text field to input
     doc_field

--- a/snorkel/slicing/monitor.py
+++ b/snorkel/slicing/monitor.py
@@ -27,5 +27,5 @@ def slice_dataframe(
     S = PandasSFApplier([slicing_function]).apply(df)
 
     # Index into the SF labels by name
-    df_idx = np.where(S[slicing_function.name])[0]
+    df_idx = np.where(S[slicing_function.name])[0]  # type: ignore
     return df.iloc[df_idx]

--- a/snorkel/slicing/sf/core.py
+++ b/snorkel/slicing/sf/core.py
@@ -24,8 +24,6 @@ class slicing_function:
         Slicing resources passed in to ``f`` via ``kwargs``
     preprocessors
         Preprocessors to run on data points before SF execution
-    fault_tolerant
-        Output ``-1`` if SF execution fails?
 
     Examples
     --------
@@ -51,14 +49,12 @@ class slicing_function:
         name: Optional[str] = None,
         resources: Optional[Mapping[str, Any]] = None,
         pre: Optional[List[BasePreprocessor]] = None,
-        fault_tolerant: bool = False,
     ) -> None:
         if callable(name):
             raise ValueError("Looks like this decorator is missing parentheses!")
         self.name = name
         self.resources = resources
         self.pre = pre
-        self.fault_tolerant = fault_tolerant
 
     def __call__(self, f: Callable[..., int]) -> SlicingFunction:
         """Wrap a function to create a ``SlicingFunction``.
@@ -74,10 +70,4 @@ class slicing_function:
             New ``SlicingFunction`` executing logic in wrapped function
         """
         name = self.name or f.__name__
-        return SlicingFunction(
-            name=name,
-            f=f,
-            resources=self.resources,
-            pre=self.pre,
-            fault_tolerant=self.fault_tolerant,
-        )
+        return SlicingFunction(name=name, f=f, resources=self.resources, pre=self.pre)

--- a/snorkel/slicing/sf/nlp.py
+++ b/snorkel/slicing/sf/nlp.py
@@ -37,8 +37,6 @@ class NLPSlicingFunction(BaseNLPLabelingFunction):
         Labeling resources passed in to ``f`` via ``kwargs``
     pre
         Preprocessors to run before SpacyPreprocessor is executed
-    fault_tolerant
-        Output -1 if LF execution fails?
     text_field
         Name of data point text field to input
     doc_field
@@ -74,8 +72,6 @@ class NLPSlicingFunction(BaseNLPLabelingFunction):
     Attributes
     ----------
     name
-        See above
-    fault_tolerant
         See above
     """
 

--- a/test/labeling/lf/test_core.py
+++ b/test/labeling/lf/test_core.py
@@ -34,30 +34,14 @@ class TestLabelingFunction(unittest.TestCase):
         self.assertEqual(lf(x_43), 0)
         self.assertEqual(lf(x_19), -1)
 
-    def _run_lf_raise(self, lf: LabelingFunction) -> None:
-        x_none = SimpleNamespace(num=None)
-        with self.assertRaises(TypeError):
-            lf(x_none)
-
-    def _run_lf_no_raise(self, lf: LabelingFunction) -> None:
-        x_none = SimpleNamespace(num=None)
-        self.assertEqual(lf(x_none), -1)
-
     def test_labeling_function(self) -> None:
         lf = LabelingFunction(name="my_lf", f=f)
         self._run_lf(lf)
-        self._run_lf_raise(lf)
-
-    def test_labeling_function_fault_tolerant(self) -> None:
-        lf = LabelingFunction(name="my_lf", f=f, fault_tolerant=True)
-        self._run_lf(lf)
-        self._run_lf_no_raise(lf)
 
     def test_labeling_function_resources(self) -> None:
         db = [3, 6, 43]
         lf = LabelingFunction(name="my_lf", f=g, resources=dict(db=db))
         self._run_lf(lf)
-        self._run_lf_no_raise(lf)
 
     def test_labeling_function_preprocessor(self) -> None:
         lf = LabelingFunction(name="my_lf", f=f, pre=[square, square])
@@ -79,7 +63,6 @@ class TestLabelingFunction(unittest.TestCase):
         lf = LabelingFunction(name="my_lf", f=g, resources=dict(db=db))
         lf_load = pickle.loads(pickle.dumps(lf))
         self._run_lf(lf_load)
-        self._run_lf_no_raise(lf_load)
 
     def test_labeling_function_decorator(self) -> None:
         @labeling_function()
@@ -89,17 +72,17 @@ class TestLabelingFunction(unittest.TestCase):
         self.assertIsInstance(lf, LabelingFunction)
         self.assertEqual(lf.name, "lf")
         self._run_lf(lf)
-        self._run_lf_raise(lf)
 
     def test_labeling_function_decorator_args(self) -> None:
-        @labeling_function(name="my_lf", fault_tolerant=True)
-        def lf(x: DataPoint) -> int:
-            return 0 if x.num > 42 else -1
+        db = [3, 6, 43 ** 2]
+
+        @labeling_function(name="my_lf", resources=dict(db=db), pre=[square])
+        def lf(x: DataPoint, db: List[int]) -> int:
+            return 0 if x.num in db else -1
 
         self.assertIsInstance(lf, LabelingFunction)
         self.assertEqual(lf.name, "my_lf")
         self._run_lf(lf)
-        self._run_lf_no_raise(lf)
 
     def test_labeling_function_decorator_no_parens(self) -> None:
         with self.assertRaisesRegex(ValueError, "missing parentheses"):


### PR DESCRIPTION
## Description of proposed changes

Stacked with #1480 

Remove the `fault_tolerant` argument from LF/SF definition. This should be specified at apply time, rather than in the LF/SF definition itself. This change also allows us to track e.g. the number of times each LF fails.

## Test plan

Remove relevant tests
