### PR TITLE
Capped-iteration LabelModel permutation sampling.

### DIFF
--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -506,6 +506,21 @@ class TestLabelModelAdvanced(unittest.TestCase):
         score = label_model.score(L, Y)
         self.assertGreaterEqual(score["accuracy"], 0.9)
 
+    def test_label_model_large_multiclass(self) -> None:
+        """Test the LabelModel's estimate of P and Y on a dataset with a high-cardinality target."""
+        np.random.seed(123)
+
+        # Generate label matrix with high cardinality.
+        cardinality: int = 20
+        P, Y, L = generate_simple_label_matrix(self.n, self.m, cardinality=cardinality)
+
+        # Train LabelModel and only allow for 100 permutation iterations. At
+        # cardinality = 20, the theoretical maximum number of permuted iterations
+        # is `20!`, which is ~2.43e18. This test should never finish unless we've
+        # properly bound the number of iterations from above.
+        label_model = LabelModel(cardinality=cardinality, verbose=False, n_iter=100)
+        label_model.fit(L, n_epochs=200, lr=0.01, seed=123)
+
     def test_label_model_sparse(self) -> None:
         """Test the LabelModel's estimate of P and Y on a sparse synthetic dataset.
 


### PR DESCRIPTION
## Description of proposed changes

This PR addresses #1486, where we found that a one unit increase in target cardinality (`k`) results in an exponential (~8-10x) increase in runtime, due to attempting to evaluate all `k!` permutations of our labeling functions while searching for an ideal `μ` in `LabelModel._break_col_permutation_symmetry`. This makes using `LabelModel` a non-starter for multi-class classification tasks with a cardinality greater than ~8.

To address this issue, we instead implement a randomized search policy over all `k!` permutations – parameterized only by `n_iter` – which is the maximum number of distinct permutations we'd like to consider before early-stopping.

### Considerations

In general there are a few questions we should be aware of:
- Would we rather have a function that maps `cardinality -> number of iterations`? Since `cardinality -> # permutations` is exponential, we'd need to linearize by applying the logarithm. But I didn't bother to try and craft a function, since it seemed more complicated than it was worth.
- The sampling policy in place attempts to sample a unique permutation from the population of `k!` permutations. It may re-generate a previous permutation, but the final sample of permutations is unique.
- I tried sticking with `itertools.permutations` to generate our samples, but found it a bit difficult to reconcile with randomly sampling along the entire space. We could chain the returned generator with `itertools.islice`, but I'm not 100% sure what the implication would be of selecting a contiguous sequence of `n_iter` permutations and claiming it's "random." Thoughts welcome here!
- It may be worth having a generator that yields a unique sample from `np.random.permutation(k)` and memoizes prior samples' hash in a set, instead. That way, we're not generating a set of `n_iter` tuples of length 17.
- This PR sets the default `n_iter` in the `LabelModelConfig` to 1 million, which gives us an amortized performance that's between cardinalities 9 and 10. This can be set by the user at model initialization time, but worth considering if that's a proper default or if we should be more conservative.

## Related issue(s)

Fixes #1486.

## Test plan

I've added a test `test_label_model_large_multiclass` under `TestLabelModelAdvanced`, which is marked as a complex test suite. It attempts to run a `LabelModel` with `cardinality = 20`, which would take a _long_ time without a capped number of iterations. Instead, I've capped the number of iterations to 100, so it finishes pretty quickly (a few seconds, modulo local computing resources).

To test, run:

```bash
tox            # General test suite.
tox -e complex # Complex test suite.
```

Anecdotally, I've also run the example from #1486 with `10 <= N_CLASSES <= 13` and the runtime is constant with respect to the provided `n_iter`. At `n_iter: int = 500_000`, here are examples of runs on my local machine:

```
Sampling from all possible permutations...: 100%|██████████| 500000/500000 [00:43<00:00, 11510.61it/s]
Searching for ideal μ amongst candidates...: 100%|██████████| 500000/500000 [03:13<00:00, 2586.52it/s]
Fitting label model with 10 classes took 238.014 seconds.
-------------------
Sampling from all possible permutations...: 100%|██████████| 500000/500000 [00:40<00:00, 12370.89it/s]
Searching for ideal μ amongst candidates...: 100%|██████████| 500000/500000 [03:22<00:00, 2473.01it/s]
Fitting label model with 11 classes took 243.921 seconds.
-------------------
Sampling from all possible permutations...: 100%|██████████| 500000/500000 [00:40<00:00, 12325.28it/s]
Searching for ideal μ amongst candidates...: 100%|██████████| 500000/500000 [03:39<00:00, 2276.67it/s]
Fitting label model with 12 classes took 261.595 seconds.
-------------------
Sampling from all possible permutations...: 100%|██████████| 500000/500000 [00:39<00:00, 12528.03it/s]
Searching for ideal μ amongst candidates...: 100%|██████████| 500000/500000 [04:00<00:00, 2075.09it/s]
Fitting label model with 13 classes took 282.288 seconds.
-------------------
```

**Note:** the runtime still increases _a bit_ with every increase in cardinality, but that's because each sampled permutation is one item larger, which adds up over `n_iter` samples. Anecdotally, as `k` increases, the time it takes to sample `n_iter` unique permutations decreases (fewer and fewer opportunities for duplicate sampling), but the core search for an ideal `μ` increases in runtime (larger matrices being generated and multiplied).

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [x] All new and existing tests passed.
