### PR TITLE
Upper bound networkx version at 2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ scikit-learn>=0.20.2,<0.22.0
 torch>=1.1.0,<1.2.0
 
 # LF dependency learning
-networkx>=2.2,<3.0
+networkx>=2.2,<2.4
 
 # Model introspection tools
 tensorboardX>=1.6,<2.0

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "tqdm>=4.33.0,<5.0.0",
         "scikit-learn>=0.20.2,<0.22.0",
         "torch>=1.1.0,<1.2.0",
-        "networkx>=2.2,<3.0",
+        "networkx>=2.2,<2.4",
         "tensorboardX>=1.6,<2.0",
     ],
     python_requires=">=3.6",


### PR DESCRIPTION
## Description of proposed changes
Upper bound the version of networkx at 2.4 instead of 3.0, following the discovery of backwards incompatibility described in #1491.

Fixes #1491

## Test plan
Regular unit tests pass.

## Checklist

Need help on these? Just ask!

* [ ] I have read the **CONTRIBUTING** document.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [x] All new and existing tests passed.
