### PR TITLE
Update exempt stale label for issues to `no-stale`

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,6 +17,6 @@ jobs:
         stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
-        exempt-issue-label: 'feature request'
+        exempt-issue-label: 'no-stale'
         days-before-stale: 30
         days-before-close: 5


### PR DESCRIPTION
## Description of proposed changes
Update the label for issues that are ignored by the stale bot to `no-stale`. This way, we fan mark both feature requests and bugs.

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [x] All new and existing tests passed.
