### PR TITLE
Fix error bucket docs to correctly reflect indexes

### DIFF
--- a/snorkel/analysis/error_analysis.py
+++ b/snorkel/analysis/error_analysis.py
@@ -30,13 +30,16 @@ def get_label_buckets(*y: np.ndarray) -> Dict[Tuple[int, ...], np.ndarray]:
     >>> buckets = get_label_buckets(Y_gold, Y_pred)
 
     The returned ``buckets[(i, j)]`` is a NumPy array of data point indices with
-    predicted label i and true label j.
+    true label i and predicted label j.
+
+    More generally, the returned indexes (i,j,k,...) match the order of labels passed
+    as function args.
 
     >>> buckets[(1, 1)]  # true positives
     array([0, 1])
-    >>> (1, 0) in buckets  # false negatives
+    >>> (1, 0) in buckets  # false positives
     False
-    >>> (0, 1) in buckets  # false positives
+    >>> (0, 1) in buckets  # false negatives
     False
     >>> (0, 0) in buckets  # true negatives
     False

--- a/snorkel/analysis/error_analysis.py
+++ b/snorkel/analysis/error_analysis.py
@@ -32,8 +32,8 @@ def get_label_buckets(*y: np.ndarray) -> Dict[Tuple[int, ...], np.ndarray]:
     The returned ``buckets[(i, j)]`` is a NumPy array of data point indices with
     true label i and predicted label j.
 
-    More generally, the returned indexes (i,j,k,...) match the order of labels passed
-    as function args.
+    More generally, the returned indices within each bucket refer to the order of the
+    labels that were passed in as function arguments.
 
     >>> buckets[(1, 1)]  # true positives
     array([0, 1])


### PR DESCRIPTION
## Description of proposed changes
Documentation is incorrect for the `get_label_buckets` utility

Fixes # (issue)
Spectrum issue specifying incorrect documentation: https://spectrum.chat/snorkel/tutorials/understanding-buckets-key-in-error-analysis-py~1b4f478f-78ab-44f4-9bfe-7c14532e88dd

## Test plan
* No functional chnages

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [x] All new and existing tests passed.
