### PR TITLE
Model baseline model imports to snorkel/labeling/model

### DIFF
--- a/docs/packages.json
+++ b/docs/packages.json
@@ -17,7 +17,11 @@
             "lf.nlp.NLPLabelingFunction",
             "lf.nlp.nlp_labeling_function",
             "lf.nlp_spark.SparkNLPLabelingFunction",
-            "lf.nlp_spark.spark_nlp_labeling_function"
+            "lf.nlp_spark.spark_nlp_labeling_function",
+            "model.baselines.MajorityClassVoter",
+            "model.baselines.MajorityLabelVoter",
+            "model.baselines.RandomVoter",
+            "model.label_model.LabelModel"
         ],
         "map": [
             "spark.make_spark_mapper"

--- a/docs/packages/labeling.rst
+++ b/docs/packages/labeling.rst
@@ -12,10 +12,14 @@ Programmatic data set labeling: LF creation, models, and analysis utilities.
    apply.dask.DaskLFApplier
    LFAnalysis
    LFApplier
+   model.label_model.LabelModel
    LabelingFunction
+   model.baselines.MajorityClassVoter
+   model.baselines.MajorityLabelVoter
    lf.nlp.NLPLabelingFunction
    PandasLFApplier
    apply.dask.PandasParallelLFApplier
+   model.baselines.RandomVoter
    apply.spark.SparkLFApplier
    lf.nlp_spark.SparkNLPLabelingFunction
    filter_unlabeled_dataframe

--- a/docs/packages/labeling.rst
+++ b/docs/packages/labeling.rst
@@ -12,14 +12,10 @@ Programmatic data set labeling: LF creation, models, and analysis utilities.
    apply.dask.DaskLFApplier
    LFAnalysis
    LFApplier
-   LabelModel
    LabelingFunction
-   MajorityClassVoter
-   MajorityLabelVoter
    lf.nlp.NLPLabelingFunction
    PandasLFApplier
    apply.dask.PandasParallelLFApplier
-   RandomVoter
    apply.spark.SparkLFApplier
    lf.nlp_spark.SparkNLPLabelingFunction
    filter_unlabeled_dataframe

--- a/snorkel/labeling/__init__.py
+++ b/snorkel/labeling/__init__.py
@@ -4,10 +4,4 @@ from .analysis import LFAnalysis  # noqa: F401
 from .apply.core import LFApplier  # noqa: F401
 from .apply.pandas import PandasLFApplier  # noqa: F401
 from .lf.core import LabelingFunction, labeling_function  # noqa: F401
-from .model.baselines import (  # noqa: F401
-    MajorityClassVoter,
-    MajorityLabelVoter,
-    RandomVoter,
-)
-from .model.label_model import LabelModel  # noqa: F401
 from .utils import filter_unlabeled_dataframe  # noqa: F401

--- a/snorkel/labeling/model/__init__.py
+++ b/snorkel/labeling/model/__init__.py
@@ -1,0 +1,2 @@
+from .baselines import MajorityClassVoter, MajorityLabelVoter, RandomVoter  # noqa: F401
+from .label_model import LabelModel  # noqa: F401

--- a/test/labeling/model/test_baseline.py
+++ b/test/labeling/model/test_baseline.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from snorkel.labeling import MajorityClassVoter, MajorityLabelVoter, RandomVoter
+from snorkel.labeling.model import MajorityClassVoter, MajorityLabelVoter, RandomVoter
 
 
 class BaselineModelTest(unittest.TestCase):

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -9,7 +9,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 
-from snorkel.labeling import LabelModel
+from snorkel.labeling.model import LabelModel
 from snorkel.labeling.model.label_model import TrainConfig
 from snorkel.synthetic.synthetic_data import generate_simple_label_matrix
 

--- a/test/labeling/test_convergence.py
+++ b/test/labeling/test_convergence.py
@@ -6,12 +6,8 @@ import pandas as pd
 import pytest
 import torch
 
-from snorkel.labeling import (
-    LabelingFunction,
-    LabelModel,
-    PandasLFApplier,
-    labeling_function,
-)
+from snorkel.labeling import LabelingFunction, PandasLFApplier, labeling_function
+from snorkel.labeling.model import LabelModel
 from snorkel.preprocess import preprocessor
 from snorkel.types import DataPoint
 


### PR DESCRIPTION
## Description of proposed changes
* `snorkel/labeling/__init__.py` contained extraneous imports for baseline models. Cleaning up dependencies by moving model imports to `snorkel/labeling/model/__init__.py`

## Test plan
* Ran `tox` + `tox -e doc` + `tox -e complex`

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [x] All new and existing tests passed.
