### PR TITLE
[EZ] Add doc sync to tox testenv:doc

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,6 @@ commands_pre =
 commands =
     isort -rc .
     black .
-    {toxinidir}/scripts/sync_api_docs.py
 
 [testenv:doc]
 description = build docs
@@ -83,3 +82,4 @@ commands =
     rm -rf docs/_build
     rm -rf docs/packages/_autosummary
     make -C docs/ html
+    {toxinidir}/scripts/sync_api_docs.py


### PR DESCRIPTION
## Description of proposed changes
* Move the tox update command to the `doc` environment in tox, so `tox -e doc` will update docs, rather than `tox -e fix.

## Test plan
* Manually updated `docs/packages.json`, ran `tox -e doc`, and saw updates to appropriate `docs/*/*.rst`

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [x] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [x] All new and existing tests passed.
