### PR TITLE
Print epoch number in fit() method of LabelModel

### DIFF
--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -892,6 +892,9 @@ class LabelModel(nn.Module):
         # Train the model
         metrics_hist = {}  # The most recently seen value for all metrics
         for epoch in range(start_iteration, self.train_config.n_epochs):
+            if self.config.verbose:
+                print("Epoch {0}/{1}".format(epoch+1, self.train_config.n_epochs))
+                
             self.running_loss = 0.0
             self.running_examples = 0
 


### PR DESCRIPTION
## Description of proposed changes

The fit() method of LabelModel runs several epochs, with default being 100. 
Added code to print epoch number before running each epoch, the same way that keras does. 

```
Epoch 1/100
Epoch 2/100
....
Epoch 100/100
```


## Related issue(s)
