### PR TITLE
Fix squeeze bug for length 1 array, and inconsistency on requirements and setup.py 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ tqdm>=4.33.0,<5.0.0
 # Internal models
 scikit-learn>=0.20.2,<0.22.0
 torch>=1.1.0,<1.2.0
-munkres==1.1.2
+munkres>=1.0.6
 
 # LF dependency learning
 networkx>=2.2,<2.4

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        "munkres==1.1.2",
+        "munkres>=1.0.6",
         "numpy>=1.16.0,<2.0.0",
         "scipy>=1.2.0,<2.0.0",
         "pandas>=0.25.0,<0.26.0",

--- a/snorkel/utils/core.py
+++ b/snorkel/utils/core.py
@@ -121,6 +121,8 @@ def to_int_label_array(X: np.ndarray, flatten_vector: bool = True) -> np.ndarray
     # Correct shape
     if flatten_vector:
         X = X.squeeze()
+        if X.ndim == 0:
+            X = np.expand_dims(X, 0)
         if X.ndim != 1:
             raise ValueError("Input could not be converted to 1d np.array")
     return X

--- a/test/utils/test_core.py
+++ b/test/utils/test_core.py
@@ -21,6 +21,10 @@ class UtilsTest(unittest.TestCase):
         Y = to_int_label_array(X, flatten_vector=True)
         np.testing.assert_array_equal(Y, Y_expected)
 
+        Y = to_int_label_array(np.array([[1]]), flatten_vector=True)
+        Y_expected = np.array([1])
+        np.testing.assert_array_equal(Y, Y_expected)
+
         Y = to_int_label_array(X, flatten_vector=False)
         Y_expected = np.array([[1], [0], [2]])
         np.testing.assert_array_equal(Y, Y_expected)


### PR DESCRIPTION
#Description of proposed changes
Squeezing a length 1 array for used to create a scalar instead of a 1D array as intended. Fixed by adding an extra check.
Also made munkres version in setup.py consistent with requirements.

## Test plan
Update unit test for changed function.

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [ ] All new and existing tests passed.
