### PR TITLE
Improve error logs for classifier operations + fix complex tests

### DIFF
--- a/snorkel/classification/multitask_classifier.py
+++ b/snorkel/classification/multitask_classifier.py
@@ -212,6 +212,7 @@ class MultitaskClassifier(nn.Module):
                                     # one field; use that as the input to the current op
                                     op_name = op_input
                                     inputs.append(outputs[op_name])
+
                             output = self.module_pool[operation.module_name].forward(
                                 *inputs
                             )
@@ -220,8 +221,10 @@ class MultitaskClassifier(nn.Module):
                             output = self.module_pool[operation.module_name].forward(
                                 outputs
                             )
-                    except Exception:
-                        raise ValueError(f"Unsuccessful operation {operation}.")
+                    except Exception as e:
+                        raise ValueError(
+                            f"Unsuccessful operation {operation}: {repr(e)}."
+                        )
                     outputs[operation.name] = output
 
         return outputs

--- a/test/classification/test_classifier_convergence.py
+++ b/test/classification/test_classifier_convergence.py
@@ -80,7 +80,7 @@ def create_data(n: int, offset=0) -> pd.DataFrame:
 
     Create labels with linear decision boundaries related to the two coordinates of X.
     """
-    X = np.random.random((n, 2)) * 2 - 1
+    X = (np.random.random((n, 2)) * 2 - 1).astype(np.float32)
     Y = (X[:, 0] < X[:, 1] + offset).astype(int)
 
     df = pd.DataFrame({"x1": X[:, 0], "x2": X[:, 1], "y": Y})

--- a/test/slicing/test_convergence.py
+++ b/test/slicing/test_convergence.py
@@ -175,7 +175,7 @@ class SlicingConvergenceTest(unittest.TestCase):
 
 
 def create_data(n: int) -> pd.DataFrame:
-    X = np.random.random((n, 2)) * 2 - 1
+    X = (np.random.random((n, 2)) * 2 - 1).astype(np.float32)
     Y = (X[:, 0] < X[:, 1] + 0.25).astype(int)
 
     df = pd.DataFrame({"x1": X[:, 0], "x2": X[:, 1], "y": Y})


### PR DESCRIPTION
## Description of proposed changes
* Show the underlying exception for failed Operations
* Fix complex tests by casting inputs to float32 (rather than doubles)

## Test plan
* Ran `tox`, `tox -e complex`, `tox -e spark` locally; passed

## Checklist
* [x] I have read the **CONTRIBUTING** document.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [x] All new and existing tests passed.
