### PR TITLE
Accept prec_init as array or list

### DIFF
--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -58,7 +58,7 @@ class TrainConfig(Config):
     optimizer_config: OptimizerConfig = OptimizerConfig()  # type: ignore
     lr_scheduler: str = "constant"
     lr_scheduler_config: LRSchedulerConfig = LRSchedulerConfig()  # type: ignore
-    prec_init: float = 0.7
+    prec_init: Union[int, float, np.ndarray, torch.Tensor] = 0.7
     seed: int = np.random.randint(1e6)
     log_freq: int = 10
     mu_eps: Optional[float] = None
@@ -280,10 +280,15 @@ class LabelModel(nn.Module, BaseLabeler):
         # Handle single values
         if isinstance(self.train_config.prec_init, (int, float)):
             self._prec_init = self.train_config.prec_init * torch.ones(self.m)
-        if isinstance(self.train_config.prec_init, np.ndarray):
+        elif isinstance(self.train_config.prec_init, np.ndarray):
             self._prec_init = torch.from_numpy(self.train_config.prec_init)
-        if isinstance(self.train_config.prec_init, list):
-            self._prec_init = torch.from_numpy(np.array(self.train_config.prec_init))
+        elif isinstance(self.train_config.prec_init, list):
+            self._prec_init = torch.Tensor(self.train_config.prec_init)
+        elif not isinstance(self.train_config.prec_init, torch.Tensor):
+            print("TYPE ERROR")
+            raise TypeError(
+                f"prec_init is of type {type(self.train_config.prec_init)} which is not supported currently."
+            )
         if self._prec_init.shape[0] != self.m:
             raise ValueError(f"prec_init must have shape {self.m}.")
 

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -280,6 +280,10 @@ class LabelModel(nn.Module, BaseLabeler):
         # Handle single values
         if isinstance(self.train_config.prec_init, (int, float)):
             self._prec_init = self.train_config.prec_init * torch.ones(self.m)
+        if isinstance(self.train_config.prec_init, np.ndarray):
+            self._prec_init = torch.from_numpy(self.train_config.prec_init)
+        if isinstance(self.train_config.prec_init, list):
+            self._prec_init = torch.from_numpy(np.array(self.train_config.prec_init))
         if self._prec_init.shape[0] != self.m:
             raise ValueError(f"prec_init must have shape {self.m}.")
 

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -58,7 +58,7 @@ class TrainConfig(Config):
     optimizer_config: OptimizerConfig = OptimizerConfig()  # type: ignore
     lr_scheduler: str = "constant"
     lr_scheduler_config: LRSchedulerConfig = LRSchedulerConfig()  # type: ignore
-    prec_init: Union[int, float, np.ndarray, torch.Tensor] = 0.7
+    prec_init: Union[float, List[float], np.ndarray, torch.Tensor] = 0.7
     seed: int = np.random.randint(1e6)
     log_freq: int = 10
     mu_eps: Optional[float] = None
@@ -281,7 +281,7 @@ class LabelModel(nn.Module, BaseLabeler):
         if isinstance(self.train_config.prec_init, (int, float)):
             self._prec_init = self.train_config.prec_init * torch.ones(self.m)
         elif isinstance(self.train_config.prec_init, np.ndarray):
-            self._prec_init = torch.from_numpy(self.train_config.prec_init)
+            self._prec_init = torch.Tensor(self.train_config.prec_init)
         elif isinstance(self.train_config.prec_init, list):
             self._prec_init = torch.Tensor(self.train_config.prec_init)
         elif not isinstance(self.train_config.prec_init, torch.Tensor):

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -285,7 +285,6 @@ class LabelModel(nn.Module, BaseLabeler):
         elif isinstance(self.train_config.prec_init, list):
             self._prec_init = torch.Tensor(self.train_config.prec_init)
         elif not isinstance(self.train_config.prec_init, torch.Tensor):
-            print("TYPE ERROR")
             raise TypeError(
                 f"prec_init is of type {type(self.train_config.prec_init)} which is not supported currently."
             )

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -65,32 +65,26 @@ class LabelModelTest(unittest.TestCase):
 
         # test without prec_init
         label_model.fit(L_train=L, n_epochs=1000, seed=123)
-        Y_pred = label_model.predict(L)
-        assert set(Y_pred.flatten()) == {0, 1}
 
         # test with prec_init as float
         prec_init = 0.6
         label_model.fit(L_train=L, prec_init=prec_init, n_epochs=1000, seed=123)
-        Y_pred = label_model.predict(L)
-        assert set(Y_pred.flatten()) == {0, 1}
+        label_model.predict(L)
 
         # test with prec_init as int
         prec_init = 1
         label_model.fit(L_train=L, prec_init=prec_init, n_epochs=1000, seed=123)
-        Y_pred = label_model.predict(L)
-        assert set(Y_pred.flatten()) == {0, 1}
+        label_model.predict(L)
 
         # test with prec_init as list
         prec_init = [0.1, 0.2, 0.3]
         label_model.fit(L_train=L, prec_init=prec_init, n_epochs=1000, seed=123)
-        Y_pred = label_model.predict(L)
-        assert set(Y_pred.flatten()) == {0, 1}
+        label_model.predict(L)
 
         # test with prec_init as np.array
         prec_init = np.array([0.1, 0.2, 0.3])
         label_model.fit(L_train=L, prec_init=prec_init, n_epochs=1000, seed=123)
-        Y_pred = label_model.predict(L)
-        assert set(Y_pred.flatten()) == {0, 1}
+        label_model.predict(L)
 
         with self.assertRaisesRegex(
             TypeError,

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -93,6 +93,14 @@ class LabelModelTest(unittest.TestCase):
         assert set(Y_pred.flatten()) == {0, 1}
 
         with self.assertRaisesRegex(
+            TypeError,
+            f"prec_init is of type <class 'str'> which is not supported currently.",
+        ):
+            # test with unsupported type (string)
+            prec_init = "skibidi bop mm dada"
+            label_model.fit(L_train=L, prec_init=prec_init, n_epochs=1000, seed=123)
+
+        with self.assertRaisesRegex(
             ValueError, f"prec_init must have shape {L.shape[1]}."
         ):
             # test with prec_init as list of wrong length (bigger)

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -66,45 +66,45 @@ class LabelModelTest(unittest.TestCase):
         # test without prec_init
         label_model.fit(L_train=L, n_epochs=1000, seed=123)
         Y_pred = label_model.predict(L)
-        assert(set(Y_pred.flatten()) == {0,1})
+        assert set(Y_pred.flatten()) == {0, 1}
 
         # test with prec_init as float
         prec_init = 0.6
-        label_model.fit(L_train = L, prec_init = prec_init, n_epochs = 1000,  seed = 123)
+        label_model.fit(L_train=L, prec_init=prec_init, n_epochs=1000, seed=123)
         Y_pred = label_model.predict(L)
-        assert(set(Y_pred.flatten()) == {0,1})
-
+        assert set(Y_pred.flatten()) == {0, 1}
 
         # test with prec_init as int
         prec_init = 1
-        label_model.fit(L_train = L, prec_init = prec_init, n_epochs = 1000,  seed = 123)
+        label_model.fit(L_train=L, prec_init=prec_init, n_epochs=1000, seed=123)
         Y_pred = label_model.predict(L)
-        assert(set(Y_pred.flatten()) == {0,1})
+        assert set(Y_pred.flatten()) == {0, 1}
 
         # test with prec_init as list
         prec_init = [0.1, 0.2, 0.3]
-        label_model.fit(L_train = L, prec_init = prec_init, n_epochs = 1000,  seed = 123)
+        label_model.fit(L_train=L, prec_init=prec_init, n_epochs=1000, seed=123)
         Y_pred = label_model.predict(L)
-        assert(set(Y_pred.flatten()) == {0,1})
+        assert set(Y_pred.flatten()) == {0, 1}
 
         # test with prec_init as np.array
         prec_init = np.array([0.1, 0.2, 0.3])
-        label_model.fit(L_train = L, prec_init = prec_init, n_epochs = 1000,  seed = 123)
+        label_model.fit(L_train=L, prec_init=prec_init, n_epochs=1000, seed=123)
         Y_pred = label_model.predict(L)
-        assert(set(Y_pred.flatten()) == {0,1})
+        assert set(Y_pred.flatten()) == {0, 1}
 
-        with self.assertRaisesRegex(ValueError, f"prec_init must have shape {L.shape[1]}."):
+        with self.assertRaisesRegex(
+            ValueError, f"prec_init must have shape {L.shape[1]}."
+        ):
             # test with prec_init as list of wrong length (bigger)
             prec_init = np.array([0.1, 0.2, 0.3, 0.4])
-            label_model.fit(L_train = L, prec_init = prec_init, n_epochs = 1000,  seed = 123)
+            label_model.fit(L_train=L, prec_init=prec_init, n_epochs=1000, seed=123)
 
-        with self.assertRaisesRegex(ValueError, f"prec_init must have shape {L.shape[1]}."):
+        with self.assertRaisesRegex(
+            ValueError, f"prec_init must have shape {L.shape[1]}."
+        ):
             # test with prec_init as list of wrong length (smaller)
             prec_init = np.array([0.1, 0.2])
-            label_model.fit(L_train = L, prec_init = prec_init, n_epochs = 1000,  seed = 123)
-
-        
-        
+            label_model.fit(L_train=L, prec_init=prec_init, n_epochs=1000, seed=123)
 
     def test_class_balance(self):
         label_model = LabelModel(cardinality=2, verbose=False)

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -94,7 +94,7 @@ class LabelModelTest(unittest.TestCase):
 
         with self.assertRaisesRegex(
             TypeError,
-            f"prec_init is of type <class 'str'> which is not supported currently.",
+            "prec_init is of type <class 'str'> which is not supported currently.",
         ):
             # test with unsupported type (string)
             prec_init = "skibidi bop mm dada"

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -59,6 +59,53 @@ class LabelModelTest(unittest.TestCase):
             label_model.predict(L), np.array([1, 1, 1])
         )
 
+    def test_prec_init(self):
+        label_model = LabelModel(cardinality=2, verbose=False)
+        L = np.array([[-1, -1, 1], [-1, 1, -1], [0, -1, -1]])
+
+        # test without prec_init
+        label_model.fit(L_train=L, n_epochs=1000, seed=123)
+        Y_pred = label_model.predict(L)
+        assert(set(Y_pred.flatten()) == {0,1})
+
+        # test with prec_init as float
+        prec_init = 0.6
+        label_model.fit(L_train = L, prec_init = prec_init, n_epochs = 1000,  seed = 123)
+        Y_pred = label_model.predict(L)
+        assert(set(Y_pred.flatten()) == {0,1})
+
+
+        # test with prec_init as int
+        prec_init = 1
+        label_model.fit(L_train = L, prec_init = prec_init, n_epochs = 1000,  seed = 123)
+        Y_pred = label_model.predict(L)
+        assert(set(Y_pred.flatten()) == {0,1})
+
+        # test with prec_init as list
+        prec_init = [0.1, 0.2, 0.3]
+        label_model.fit(L_train = L, prec_init = prec_init, n_epochs = 1000,  seed = 123)
+        Y_pred = label_model.predict(L)
+        assert(set(Y_pred.flatten()) == {0,1})
+
+        # test with prec_init as np.array
+        prec_init = np.array([0.1, 0.2, 0.3])
+        label_model.fit(L_train = L, prec_init = prec_init, n_epochs = 1000,  seed = 123)
+        Y_pred = label_model.predict(L)
+        assert(set(Y_pred.flatten()) == {0,1})
+
+        with self.assertRaisesRegex(ValueError, f"prec_init must have shape {L.shape[1]}."):
+            # test with prec_init as list of wrong length (bigger)
+            prec_init = np.array([0.1, 0.2, 0.3, 0.4])
+            label_model.fit(L_train = L, prec_init = prec_init, n_epochs = 1000,  seed = 123)
+
+        with self.assertRaisesRegex(ValueError, f"prec_init must have shape {L.shape[1]}."):
+            # test with prec_init as list of wrong length (smaller)
+            prec_init = np.array([0.1, 0.2])
+            label_model.fit(L_train = L, prec_init = prec_init, n_epochs = 1000,  seed = 123)
+
+        
+        
+
     def test_class_balance(self):
         label_model = LabelModel(cardinality=2, verbose=False)
         # Test class balance


### PR DESCRIPTION
## Description of proposed changes
Currently, `LabelModel` only accepts a `float` or an `int` for `prec_init`. These get converted into a 1D tensor of the same value. In this pull request, `prec_init` can be passed as  `np.ndarray` or as a Python list also. This way different labeling functions can get assigned different priors.

## Related issue(s)

Fixes #1484

## Test plan

## Checklist

Need help on these? Just ask!

* [ ✅ ] I have read the **CONTRIBUTING** document.
* [ ✅ ] I have updated the documentation accordingly.
* [ ✅ ] I have added tests to cover my changes.
* [ ✅ ] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [ ✅ ] All new and existing tests passed.
