### PR TITLE
Update pandas to stable version and numpy accordingly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,11 @@
 #### ESSENTIAL LIBRARIES
 
 # General scientific computing
-numpy>=1.16.0,<1.20.0
+numpy>=1.16.5,<1.20.0
 scipy>=1.2.0,<2.0.0
 
 # Data storage and function application
-pandas>=0.25.0,<2.0.0
+pandas>=1.0.0,<2.0.0
 tqdm>=4.33.0,<5.0.0
 
 # Internal models

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,9 @@ setup(
     include_package_data=True,
     install_requires=[
         "munkres>=1.0.6",
-        "numpy>=1.16.0,<1.20.0",
+        "numpy>=1.16.5,<1.20.0",
         "scipy>=1.2.0,<2.0.0",
-        "pandas>=0.25.0,<2.0.0",
+        "pandas>=1.0.0,<2.0.0",
         "tqdm>=4.33.0,<5.0.0",
         "scikit-learn>=0.20.2,<0.25.0",
         "torch>=1.2.0,<2.0.0",


### PR DESCRIPTION
## Description of proposed changes
With the previous set of dependencies, I observed the following error after pip installing snorkel v0.9.6 (pandas==1.2.3):
```
ImportError: this version of pandas is incompatible with numpy < 1.16.5
your numpy version is 1.16.2.
Please upgrade numpy to >= 1.16.5 to use this pandas version
```
This PR (a) updates pandas to the stable version 1.0.0+ to hopefully reduce backward compatibility issues moving forward, and (b) updates the numpy patch number in accordance with the above error message.

Fixes #1632

## Test plan
Executed the sample code from PR #1632 without these changes and observed the above error message, and with these updated package versions and observed expected behavior.

## Checklist

Need help on these? Just ask!

* [X] I have read the **CONTRIBUTING** document.
* [X] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [X] All new and existing tests passed.
