### PR TITLE
[RELEASE]: v0.9.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+.pypirc
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [0.9.7]
+## [0.9.8]
 ### [Breaking Changes]
 ### [Added]
 ### [Changed]
 ### [Deprecated]
 ### [Removed]
+
+## [0.9.7] - 2021-03-03
+### [Breaking Changes]
+
+* PR #1633, #1628: Update requirements for `numpy` (>=1.16.5,<1.20.0), `pandas` (>=1.0.0,<2.0.0), and `scikit-learn` (>=0.20.2,<0.25.0)
+
+### [Added]
+
+* PR #1628: Add unit test coverage for Python 3.8
+* PR #1616: Accept prec_init as array or list in `LabelModel`
+* PR #1602: Add get_label_instances to analysis module
+
+### [Contributors]
+
+Thanks to @DavidKoleczek and @antonis19 for contributions!
 
 ## [0.9.6] - 2020-08-08
 ### [Added]

--- a/snorkel/version.py
+++ b/snorkel/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "0"
 _MINOR = "9"
-_REVISION = "6+dev"
+_REVISION = "7"
 
 VERSION_SHORT = f"{_MAJOR}.{_MINOR}"
 VERSION = f"{_MAJOR}.{_MINOR}.{_REVISION}"


### PR DESCRIPTION
Add changelog and bump version. Add `.pypirc` to Github to avoid accidental addition of pypi credentials.