### PR TITLE
Modify test to permit higher cardinality cases for label model

### DIFF
--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -559,7 +559,10 @@ class TestLabelModelAdvanced(unittest.TestCase):
 
         # Test estimated LF conditional probabilities
         P_lm = label_model.get_conditional_probs()
-        np.testing.assert_array_almost_equal(P, P_lm, decimal=2)
+        conditional_probs_err = (
+            np.linalg.norm(P.flatten() - P_lm.flatten(), ord=1) / P.size
+        )
+        self.assertLessEqual(conditional_probs_err, 0.01)
 
         # Test predicted labels
         score = label_model.score(L, Y)
@@ -583,7 +586,10 @@ class TestLabelModelAdvanced(unittest.TestCase):
 
         # Test estimated LF conditional probabilities
         P_lm = label_model.get_conditional_probs()
-        np.testing.assert_array_almost_equal(P, P_lm, decimal=2)
+        conditional_probs_err = (
+            np.linalg.norm(P.flatten() - P_lm.flatten(), ord=1) / P.size
+        )
+        self.assertLessEqual(conditional_probs_err, 0.01)
 
         # Test predicted labels *only on non-abstained data points*
         Y_pred = label_model.predict(L, tie_break_policy="abstain")


### PR DESCRIPTION
## Description of proposed changes
The test_label_model_basic and test_label_model_sparse tests are specific to binary class; increasing the cardinality of the problem beyond 2 (which increases the number of parameters) prevents the tests from passing.

This change modifies the tests to use average error (which is invariant to the number of parameters) instead of maximum error (which makes higher-cardinality tests increasingly difficult).

## Related issue(s)
Fixes #1631

## Test plan
I ran the scenario in #1631 with cardinality 3,4,...,10 and the tests pass.

## Checklist

Need help on these? Just ask!

* [X] I have read the **CONTRIBUTING** document.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [X] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [X] All new and existing tests passed.
