### PR TITLE
Update spark test to avoid warning message

### DIFF
--- a/test/labeling/apply/lf_applier_spark_test_script.py
+++ b/test/labeling/apply/lf_applier_spark_test_script.py
@@ -43,12 +43,12 @@ logging.basicConfig(level=logging.INFO)
 
 @labeling_function()
 def f(x: DataPoint) -> int:
-    return 1 if x.a > 42 else 0
+    return 1 if x > 42 else 0
 
 
 @labeling_function(resources=dict(db=[3, 6, 9]))
 def g(x: DataPoint, db: List[int]) -> int:
-    return 1 if x.a in db else 0
+    return 1 if x in db else 0
 
 
 DATA = [3, 43, 12, 9]


### PR DESCRIPTION
Given that the type of data is int, as is, this throws "AttributeError: 'int' object has no attribute 'a' "

## Description of proposed changes

## Related issue(s)

Fixes # (issue)

## Test plan

## Checklist

Need help on these? Just ask!

* [ ] I have read the **CONTRIBUTING** document.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [ ] All new and existing tests passed.
