### PR TITLE
Compatibility with networkx 2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ torch>=1.2.0,<2.0.0
 munkres>=1.0.6
 
 # LF dependency learning
-networkx>=2.2,<2.4
+networkx>=2.2,<2.6
 
 # Model introspection tools
 tensorboard>=1.14.0,<2.0.0

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "scikit-learn>=0.20.2,<0.25.0",
         "torch>=1.2.0,<2.0.0",
         "tensorboard>=1.14.0,<2.0.0",
-        "networkx>=2.2,<2.4",
+        "networkx>=2.2,<2.6",
     ],
     python_requires=">=3.6",
     keywords="machine-learning ai weak-supervision",

--- a/snorkel/labeling/model/graph_utils.py
+++ b/snorkel/labeling/model/graph_utils.py
@@ -8,7 +8,7 @@ def get_clique_tree(nodes: Iterable[int], edges: List[Tuple[int, int]]) -> nx.Gr
     Given a set of int nodes i and edges (i,j), returns a clique tree.
 
     Clique tree is an object G for which:
-    - G.node[i]['members'] contains the set of original nodes in the ith
+    - G.nodes[i]['members'] contains the set of original nodes in the ith
         maximal clique
     - G[i][j]['members'] contains the set of original nodes in the seperator
         set between maximal cliques i and j
@@ -46,7 +46,7 @@ def get_clique_tree(nodes: Iterable[int], edges: List[Tuple[int, int]]) -> nx.Gr
         G2.add_node(i, members=c)
     for i in G2.nodes:
         for j in G2.nodes:
-            S = G2.node[i]["members"].intersection(G2.node[j]["members"])
+            S = G2.nodes[i]["members"].intersection(G2.nodes[j]["members"])
             w = len(S)
             if w > 0:
                 G2.add_edge(i, j, weight=w, members=S)

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -197,7 +197,7 @@ class LabelModel(nn.Module, BaseLabeler):
                     [
                         j
                         for j in self.c_tree.nodes()
-                        if i in self.c_tree.node[j]["members"]
+                        if i in self.c_tree.nodes[j]["members"]
                     ]
                 ),
             )
@@ -211,7 +211,7 @@ class LabelModel(nn.Module, BaseLabeler):
             L_aug = np.copy(L_ind)
             for item in chain(self.c_tree.nodes(), self.c_tree.edges()):
                 if isinstance(item, int):
-                    C = self.c_tree.node[item]
+                    C = self.c_tree.nodes[item]
                 elif isinstance(item, tuple):
                     C = self.c_tree[item[0]][item[1]]
                 else:

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -197,15 +197,13 @@ class LabelModelTest(unittest.TestCase):
                     self.assertEqual(L_aug[i, j * k + L_shift[i, j] - 1], 1)
 
         # Finally, check the clique entries
-        # Singleton clique 1
-        self.assertEqual(len(lm.c_tree.node[1]["members"]), 1)
-        j = lm.c_tree.node[1]["start_index"]
-        self.assertEqual(L_aug[0, j], 1)
-
-        # Singleton clique 2
-        self.assertEqual(len(lm.c_tree.node[2]["members"]), 1)
-        j = lm.c_tree.node[2]["start_index"]
-        self.assertEqual(L_aug[0, j + 1], 0)
+        for j in range(m):
+            node = lm.c_tree.nodes[i]
+            self.assertEqual(len(node["members"]), 1)
+            if 1 in node["members"]:
+                self.assertEqual(L_aug[0, node["start_index"]], 1)
+            if 2 in node["members"]:
+                self.assertEqual(L_aug[0, 1 + node["start_index"]], 0)
 
     def test_conditional_probs(self):
         L = np.array([[0, 1, 0], [0, 1, 0]])


### PR DESCRIPTION
Fixes #1644

## Description of proposed changes

networkx 2.5 has been out for a while now, and some deprecated apis were removed in 2.4 or so.  This code should be compatible with any version in the 2.2-2.5 range, although there is a test failure near the "Singleton clique" comments.

## Related issue(s)

Fixes #1644 

## Test plan

Ran the unittests.  `tox -e py37`.  One failure, noted above, which I could use help understanding.

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [n/a] I have updated the documentation accordingly.
* [n/a] I have added tests to cover my changes.
* [n/a] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [x] All new and existing tests passed.
