### PR TITLE
Add tqdm progress bar on  label fit method

### DIFF
--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -3,13 +3,13 @@ import random
 from collections import Counter, defaultdict
 from itertools import chain
 from typing import Any, DefaultDict, Dict, List, NamedTuple, Optional, Set, Tuple, Union
-from tqdm import tqdm
 
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.optim as optim
 from munkres import Munkres  # type: ignore
+from tqdm import tqdm
 
 from snorkel.labeling.analysis import LFAnalysis
 from snorkel.labeling.model.base_labeler import BaseLabeler

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -9,7 +9,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 from munkres import Munkres  # type: ignore
-from tqdm import tqdm
+from tqdm import trange
 
 from snorkel.labeling.analysis import LFAnalysis
 from snorkel.labeling.model.base_labeler import BaseLabeler
@@ -810,6 +810,7 @@ class LabelModel(nn.Module, BaseLabeler):
         L_train: np.ndarray,
         Y_dev: Optional[np.ndarray] = None,
         class_balance: Optional[List[float]] = None,
+        progress_bar: bool = True,
         **kwargs: Any,
     ) -> None:
         """Train label model.
@@ -824,6 +825,8 @@ class LabelModel(nn.Module, BaseLabeler):
             Gold labels for dev set for estimating class_balance, by default None
         class_balance
             Each class's percentage of the population, by default None
+        progress_bar
+            To display a progress bar, by default True
         **kwargs
             Arguments for changing train config defaults.
 
@@ -920,35 +923,41 @@ class LabelModel(nn.Module, BaseLabeler):
         # Train the model
         metrics_hist = {}  # The most recently seen value for all metrics
 
-        with tqdm(
-            range(start_iteration, self.train_config.n_epochs), unit="epoch"
-        ) as tepoch:
-            for epoch in tepoch:
-                self.running_loss = 0.0
-                self.running_examples = 0
+        if progress_bar:
+            epochs = trange(start_iteration, self.train_config.n_epochs, unit="epoch")
+        else:
+            epochs = range(start_iteration, self.train_config.n_epochs)
 
-                # Zero the parameter gradients
-                self.optimizer.zero_grad()
+        for epoch in epochs:
+            self.running_loss = 0.0
+            self.running_examples = 0
 
-                # Forward pass to calculate the average loss per example
-                loss = self._loss_mu(l2=self.train_config.l2)
-                if torch.isnan(loss):
-                    msg = "Loss is NaN. Consider reducing learning rate."
-                    raise Exception(msg)
+            # Zero the parameter gradients
+            self.optimizer.zero_grad()
 
-                # Backward pass to calculate gradients
-                # Loss is an average loss per example
-                loss.backward()
+            # Forward pass to calculate the average loss per example
+            loss = self._loss_mu(l2=self.train_config.l2)
+            if torch.isnan(loss):
+                msg = "Loss is NaN. Consider reducing learning rate."
+                raise Exception(msg)
 
-                # Perform optimizer step
-                self.optimizer.step()
+            # Backward pass to calculate gradients
+            # Loss is an average loss per example
+            loss.backward()
 
-                # Calculate metrics, log, and checkpoint as necessary
-                metrics_dict = self._execute_logging(loss)
-                metrics_hist.update(metrics_dict)
+            # Perform optimizer step
+            self.optimizer.step()
 
-                # Update learning rate
-                self._update_lr_scheduler(epoch)
+            # Calculate metrics, log, and checkpoint as necessary
+            metrics_dict = self._execute_logging(loss)
+            metrics_hist.update(metrics_dict)
+
+            # Update learning rate
+            self._update_lr_scheduler(epoch)
+
+        # Cleanup progress bar if enabled
+        if progress_bar:
+            epochs.close()
 
         # Post-processing operations on mu
         self._clamp_params()

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -920,7 +920,9 @@ class LabelModel(nn.Module, BaseLabeler):
         # Train the model
         metrics_hist = {}  # The most recently seen value for all metrics
 
-        with tqdm(range(start_iteration, self.train_config.n_epochs), unit="epoch") as tepoch:
+        with tqdm(
+            range(start_iteration, self.train_config.n_epochs), unit="epoch"
+        ) as tepoch:
             for epoch in tepoch:
                 self.running_loss = 0.0
                 self.running_examples = 0

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -341,6 +341,19 @@ class LabelModelTest(unittest.TestCase):
         results_expected = dict(accuracy=0.5, f1=2 / 3)
         self.assertEqual(results, results_expected)
 
+    def test_progress_bar(self):
+        L = np.array([[1, 1, 0], [-1, -1, -1], [1, 0, 1]])
+        Y = np.array([1, 0, 1])
+        label_model = LabelModel(cardinality=2, verbose=False)
+        label_model.fit(L, n_epochs=100, progress_bar=False)
+        results = label_model.score(L, Y, metrics=["accuracy", "coverage"])
+        np.testing.assert_array_almost_equal(
+            label_model.predict(L), np.array([1, -1, 1])
+        )
+
+        results_expected = dict(accuracy=1.0, coverage=2 / 3)
+        self.assertEqual(results, results_expected)
+
     def test_loss(self):
         L = np.array([[0, -1, 0], [0, 1, -1]])
         label_model = LabelModel(cardinality=2, verbose=False)


### PR DESCRIPTION
Fixes #1624

## Description of proposed changes

Added a tqdm progress bar when `fit()` method on `LabelModel` is called. It updates after each epoch.
<img width="631" alt="tqdm2" src="https://user-images.githubusercontent.com/43729346/118387988-4282df00-b63f-11eb-9984-e6d0a08dbcc5.png">

When log frequency for loss reporting is enabled, it will be formatted this way.
<img width="644" alt="tqdm3" src="https://user-images.githubusercontent.com/43729346/118387995-49a9ed00-b63f-11eb-80d5-6d7937b791c7.png">

Please let me know if I should add a `progress_bar` parameter to `fit()`, similar to `apply()` method in `PandasLFApplier`

## Related issue(s)

Fixes #1624 

## Test plan
No new test has been added, as these changes do not modify the logic

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [n/a] I have updated the documentation accordingly.
* [n/a] I have added tests to cover my changes.
* [n/a] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [x] All new and existing tests passed.
