### PR TITLE
Update numpy to >=1.20.0

### DIFF
--- a/requirements-pyspark.txt
+++ b/requirements-pyspark.txt
@@ -1,3 +1,3 @@
 # Note: we don't include PySpark in the normal required installs.
 # Installing a new version may overwrite your existing system install.
-pyspark==2.4.3
+pyspark>=3.0.0,<3.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 #### ESSENTIAL LIBRARIES
 
 # General scientific computing
-numpy>=1.20.0,<1.21.0
+numpy>=1.19.0,<1.21.0
 scipy>=1.2.0,<2.0.0
 
 # Data storage and function application

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 #### ESSENTIAL LIBRARIES
 
 # General scientific computing
-numpy>=1.16.5,<1.20.0
+numpy>=1.20.0,<1.21.0
 scipy>=1.2.0,<2.0.0
 
 # Data storage and function application

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "munkres>=1.0.6",
-        "numpy>=1.20.0,<1.21.0",
+        "numpy>=1.19.0,<1.21.0",
         "scipy>=1.2.0,<2.0.0",
         "pandas>=1.0.0,<2.0.0",
         "tqdm>=4.33.0,<5.0.0",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "munkres>=1.0.6",
-        "numpy>=1.16.5,<1.20.0",
+        "numpy>=1.20.0,<1.21.0",
         "scipy>=1.2.0,<2.0.0",
         "pandas>=1.0.0,<2.0.0",
         "tqdm>=4.33.0,<5.0.0",

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -557,7 +557,9 @@ class LabelModel(nn.Module, BaseLabeler):
         return loss_1 + loss_2 + self._loss_l2(l2=l2)
 
     def _set_class_balance(
-        self, class_balance: Optional[List[float]], Y_dev: np.ndarray
+        self,
+        class_balance: Optional[List[float]] = None,
+        Y_dev: Optional[np.ndarray] = None,
     ) -> None:
         """Set a prior for the class balance.
 


### PR DESCRIPTION
## Description of proposed changes
Update numpy to resolve incompatibility with spacy, resulting in the following error message and failing CI tests on `master`:

```
ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject
```

## Test plan
Unit tests fail previously, confirm they pass after this update

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [x] I have updated the documentation accordingly.
* [N/A] I have added tests to cover my changes.
* [x] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [x] All new and existing tests passed.
