### PR TITLE
prevent pollution of top level 'test' namespace in site-packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "Bug Reports": "https://github.com/snorkel-team/snorkel/issues",
         "Citation": "https://doi.org/10.14778/3157794.3157797",
     },
-    packages=find_packages(),
+    packages=find_packages(exclude=("test*",)),
     include_package_data=True,
     install_requires=[
         "munkres>=1.0.6",


### PR DESCRIPTION
## Description of proposed changes

the `./test` directory was leaking into `site-packages` due to a misconfigured call to `find_packages`

## Related issue(s)

## Test plan

before:

```console
$ git clean -fxfd >& /dev/null && python setup.py bdist_wheel >& /dev/null && unzip -l dist/*.whl | grep test
        0  2021-08-20 14:00   test/__init__.py
        0  2021-08-20 14:00   test/augmentation/__init__.py
        0  2021-08-20 14:00   test/augmentation/apply/__init__.py
    11665  2021-08-20 14:00   test/augmentation/apply/test_tf_applier.py
        0  2021-08-20 14:00   test/augmentation/policy/__init__.py
      693  2021-08-20 14:00   test/augmentation/policy/test_core.py
      907  2021-08-20 14:00   test/augmentation/policy/test_sampling.py
        0  2021-08-20 14:00   test/classification/__init__.py
...
```

after:

```console
$ git clean -fxfd >& /dev/null && python setup.py bdist_wheel >& /dev/null && unzip -l dist/*.whl | grep test
$
```


## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [ ] I have updated the documentation accordingly. **N/A**
* [ ] I have added tests to cover my changes. **N/A**
* [ ] I have run `tox -e complex` and/or `tox -e spark` if appropriate. **N/A**
* [x] All new and existing tests passed.
