### PR TITLE
clean up flake8 ignores

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,16 +10,12 @@ doctest_optionflags =
     FLOAT_CMP
 
 [flake8]
-ignore =
+extend-ignore =
     E203,
     E265, # Throws errors for '#%%' delimiter in VSCode jupyter notebook syntax
-    E266,
     E501,
     E731,
     E741,
-    W503,
-    W605,
-    F403
 exclude =
     .eggs,
     .git,

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -906,7 +906,7 @@ class LabelModel(nn.Module, BaseLabeler):
 
         # Estimate \mu
         if self.config.verbose:  # pragma: no cover
-            logging.info("Estimating \mu...")
+            logging.info(r"Estimating \mu...")
 
         # Set model to train mode
         self.train()

--- a/test/labeling/apply/lf_applier_spark_test_script.py
+++ b/test/labeling/apply/lf_applier_spark_test_script.py
@@ -17,7 +17,7 @@ To test on AWS EMR:
     3. Run
         ```
         sudo sed -i -e \
-            '$a\export PYSPARK_PYTHON=/usr/bin/python3' \
+            '$a\\export PYSPARK_PYTHON=/usr/bin/python3' \
             /etc/spark/conf/spark-env.sh
         ```
     4. Run


### PR DESCRIPTION
- W605 should not be ignored, it will become a syntax error in the future
    - I fixed the offenders automatically with [pyupgrade]
- `extend-ignore` is better than `ignore` as it preserves the default ignore
  list

[pyupgrade]: https://github.com/asottile/pyupgrade

## Description of proposed changes

## Related issue(s)

## Test plan

- `python -Wonce -c 'import snorkel.labeling.model.label_model'`
- `python -Wonce -c 'import test.labeling.apply.lf_applier_spark_test_script'`

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [ ] I have updated the documentation accordingly. **N/A**
* [x] I have added tests to cover my changes.
* [ ] I have run `tox -e complex` and/or `tox -e spark` if appropriate. **N/A**
* [x] All new and existing tests passed.
