### PR TITLE
fixed lambda LR saving bug

### DIFF
--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -17,7 +17,7 @@ from snorkel.labeling.model.graph_utils import get_clique_tree
 from snorkel.labeling.model.logger import Logger
 from snorkel.types import Config
 from snorkel.utils.config_utils import merge_config
-from snorkel.utils.lr_schedulers import LRSchedulerConfig
+from snorkel.utils.lr_schedulers import LRPolicy, LRSchedulerConfig
 from snorkel.utils.optimizers import OptimizerConfig
 
 Metrics = Dict[str, float]
@@ -675,7 +675,7 @@ class LabelModel(nn.Module, BaseLabeler):
                 total_steps - self.warmup_steps
             )
             lr_scheduler = optim.lr_scheduler.LambdaLR(  # type: ignore
-                self.optimizer, linear_decay_func
+                self.optimizer, lr_lambda=LRPolicy(self.warmup_steps, total_steps)
             )
         elif lr_scheduler_name == "exponential":
             lr_scheduler = optim.lr_scheduler.ExponentialLR(

--- a/snorkel/utils/lr_schedulers.py
+++ b/snorkel/utils/lr_schedulers.py
@@ -42,3 +42,14 @@ class LRSchedulerConfig(Config):
     min_lr: float = 0.0  # minimum learning rate
     exponential_config: ExponentialLRSchedulerConfig = ExponentialLRSchedulerConfig()  # type:ignore
     step_config: StepLRSchedulerConfig = StepLRSchedulerConfig()  # type:ignore
+
+
+class LRPolicy(object):
+    def __init__(self, warmup_steps, total_steps):
+        self.warmup_steps = warmup_steps
+        self.total_steps = total_steps
+
+    def __call__(self, epoch):
+        return (self.total_steps - self.warmup_steps - epoch) / (
+            self.total_steps - self.warmup_steps
+        )

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -1,9 +1,9 @@
+import os
 import shutil
 import tempfile
 import unittest
 from typing import List
 
-import os
 import numpy as np
 import pytest
 import torch

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -3,6 +3,7 @@ import tempfile
 import unittest
 from typing import List
 
+import os
 import numpy as np
 import pytest
 import torch
@@ -547,6 +548,23 @@ class LabelModelTest(unittest.TestCase):
         label_model._break_col_permutation_symmetry()
         self.assertEqual(label_model.mu.data[0, 0], 0.15)
         self.assertEqual(label_model.mu.data[1, 1], 0.3)
+
+    def test_lambda_lr_save(self):
+        label_model = LabelModel(cardinality=2)
+        L_train = np.array(
+            [[1, 0, 1], [1, 1, 1], [1, 0, 1], [1, 1, 0], [0, 0, 0], [1, 1, 1]]
+        )
+        label_model.fit(
+            L_train=L_train,
+            n_epochs=500,
+            lr=0.001,
+            lr_scheduler="linear",
+            optimizer="adam",
+            log_freq=100,
+            seed=123,
+        )
+        label_model.save("./test_save.pickle")
+        os.remove("./test_save.pickle")
 
 
 @pytest.mark.complex


### PR DESCRIPTION
## Description of proposed changes
This PR fixes a probelm with the LambaLR scheduler in which label models trained with it can't be serialized properly because it uses a lambda function which pickle doesn't save. I fixed it by changing the scheduler to be class based using this as reference https://stackoverflow.com/questions/52758051/how-to-save-lambdalr-scheduler-in-pytorch-with-lambda-function
## Related issue(s)
https://github.com/snorkel-team/snorkel/issues/1658
Fixes # (issue)

## Test plan
I added a UT where I set a label model using this scheduler and ensured that now it can be saved
## Checklist

Need help on these? Just ask!

*  ✅ I have read the **CONTRIBUTING** document.
*  ✅ I have updated the documentation accordingly.
*  ✅  I have added tests to cover my changes.
*  ✅  I have run `tox -e complex` and/or `tox -e spark` if appropriate.
*  ✅  All new and existing tests passed.
