### PR TITLE
Bump networkx version to 27

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ torch>=1.2.0,<2.0.0
 munkres>=1.0.6
 
 # LF dependency learning
-networkx>=2.2,<2.6
+networkx>=2.2,<2.7
 
 # Model introspection tools
 tensorboard>=2.0.0,<2.7.0

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "scikit-learn>=0.20.2,<0.25.0",
         "torch>=1.2.0,<2.0.0",
         "tensorboard>=2.0.0,<2.7.0",
-        "networkx>=2.2,<2.6",
+        "networkx>=2.2,<2.7",
     ],
     python_requires=">=3.6",
     keywords="machine-learning ai weak-supervision",


### PR DESCRIPTION
This PR has been replaced by https://github.com/snorkel-team/snorkel/pull/1677

## Description of proposed changes

This PR bumps up the version upper boundary of [networkx](https://github.com/networkx/networkx) from `<2.6` to `<2.7`. 

The main reason for bumping the version is the existence of [high severity security vulnerability to Deserialization of Untrusted Data](https://snyk.io/vuln/SNYK-PYTHON-NETWORKX-1062709) in [networkx](https://github.com/networkx/networkx) package (fixed in v2.6).

**Note:**
networkx 2.5.x supports Python >= 3.6, while networkx 2.6.x supports Python >= 3.7. Therefore, when no other constraints are given, networkx 2.5.x is installed when on py36, while networkx 2.6.x is installed when on py3.7. 

**Historical context:**
Originally, snorkel allowed networkx `<3.0` until snorkel [`v0.9.2`](https://github.com/snorkel-team/snorkel/releases/tag/v0.9.2) (networkx bounds changed to `<2.4` by https://github.com/snorkel-team/snorkel/pull/1492 for backward compatibility reasons). Subsequently, PR https://github.com/snorkel-team/snorkel/pull/1645 introduced changes improving the compatibility and extended the networkx's version upper bound to `<2.6` (this happened before networkx 2.6 was released).

- [networkx 2.6 Release Notes](https://networkx.org/documentation/stable/release/release_2.6.html) - From the changelog, it seems that no change should impact Snorkel's use of networkx.

## Related issue(s)

Fixes #1673 

## Test plan

- `tox -e py36` on Python 3.6 with `networkx==2.5.1` installed - PASSED
- `tox -e py37` on Python 3.7 with `networkx==2.5.1` installed - PASSED
- `tox -e py37` on Python 3.7 with `networkx==2.6.3` installed - PASSED

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [ ] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [ ] All new and existing tests passed.
