### PR TITLE
Weight lf

### DIFF
--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -566,7 +566,7 @@ class LabelModel(nn.Module, BaseLabeler):
     def _set_lf_weight(self, lf_weights: Optional[List[float]]) -> None:
         """Set a prior weight for labeling functions.
 
-        Default all labeling function has the equal weight
+        Default all labeling function has the equal weight 1
         """
         self.lf_weights_aug = np.ones((self.m * self.cardinality))
         if lf_weights is not None:
@@ -849,6 +849,8 @@ class LabelModel(nn.Module, BaseLabeler):
             An [n,m] matrix with values in {-1,0,1,...,k-1}
         Y_dev
             Gold labels for dev set for estimating class_balance, by default None
+        lf_weights
+            List of floats as weight of each labeling function, by default 1 for each lf
         class_balance
             Each class's percentage of the population, by default None
         progress_bar

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -108,6 +108,23 @@ class LabelModelTest(unittest.TestCase):
             prec_init = np.array([0.1, 0.2])
             label_model.fit(L_train=L, prec_init=prec_init, n_epochs=1000, seed=123)
 
+    def test_lf_weight(self):
+        label_model = LabelModel(cardinality=2, verbose=False)
+        L = np.array([[-1, 1, -1], [-1, 1, -1], [1, -1, -1], [-1, 1, -1]])
+        label_model._set_constants(L)
+        label_model._set_lf_weight(lf_weights=None)
+
+        # Test default weight
+        np.testing.assert_array_almost_equal(
+            label_model.lf_weights_aug, np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
+        )
+        # Test customized weight
+        lf_weights = np.array([1.0, 2.0, 3.0])
+        label_model._set_lf_weight(lf_weights=lf_weights)
+        np.testing.assert_array_almost_equal(
+            label_model.lf_weights_aug, np.array([1.0, 1.0, 2.0, 2.0, 3.0, 3.0])
+        )
+
     def test_class_balance(self):
         label_model = LabelModel(cardinality=2, verbose=False)
         # Test class balance


### PR DESCRIPTION
## Description of proposed changes
It is not supported to manually weight different labeling functions.
A possible workaround is to duplicate labeling functions.
This PR adds capability of customized labeling function weights, by changing their contribution to loss_mu


## Related issue(s)
https://github.com/snorkel-team/snorkel/issues/1483
Fixes # (issue)
https://github.com/snorkel-team/snorkel/issues/1483

## Test plan
Create and pass test for additional functions, like _set_lf_weight
Add one more arg of fit for LabelModel with default=None

Experiment spam in snorkel-tutorial in jupyter notebook, get reasonable results
Majority Vote Accuracy:   84.0%
Label Model with equal weight Accuracy:     86.0%
Label Model with random weight Accuracy:     81.2%

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [x] All new and existing tests passed.
