### PR TITLE
Fix branch filtering for complex tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ run_complex: &run_complex
     branches:
       only:
         - master
-        - release-v.*
+        - /release-v.*/
     tags:
       only: /.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,8 @@ run_complex: &run_complex
   filters:
     branches:
       only:
-        - (master|release-v.*)
+        - master
+        - release-v.*
     tags:
       only: /.*/
 


### PR DESCRIPTION
## Description of proposed changes
This fixes the CI for the Complex Tests, during the migration to Circle there was an error in the branch filtering for when to run the complex tests resulting in them not being run upon a merge. This has been fixed
## Related issue(s)

Fixes # (issue)

## Test plan
I tested this in a forked version of the repo and confirmed that when I set the branch names in the new way the complex tests will be run and they won't otherwise
## Checklist

Need help on these? Just ask!

* [ ] I have read the **CONTRIBUTING** document.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [ ] All new and existing tests passed.
