### PR TITLE
Bumping numpy version for Mac M1 compat

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 #### ESSENTIAL LIBRARIES
 
 # General scientific computing
-numpy>=1.16.5,<1.20.0
+numpy>=1.16.5,<1.22.0
 scipy>=1.2.0,<2.0.0
 
 # Data storage and function application

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,8 @@
 #### ESSENTIAL LIBRARIES
 
 # General scientific computing
-numpy>=1.16.5,<1.22.0
+
+numpy>=1.16.5,<=1.22.3
 scipy>=1.2.0,<2.0.0
 
 # Data storage and function application
@@ -31,7 +32,7 @@ tensorboard>=2.0.0,<2.7.0
 
 # spaCy (NLP)
 spacy>=2.1.0,<3.0.0
-blis>=0.3.0,<0.5.0
+blis>=0.3.0,<=0.7.7
 
 # Dask (parallelism)
 dask[dataframe]>=2.1.0,<2.31.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "munkres>=1.0.6",
-        "numpy>=1.16.5,<1.20.0",
+        "numpy>=1.16.5,<1.22.0",
         "scipy>=1.2.0,<2.0.0",
         "pandas>=1.0.0,<2.0.0",
         "tqdm>=4.33.0,<5.0.0",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "munkres>=1.0.6",
-        "numpy>=1.16.5,<1.22.0",
+        "numpy>=1.16.5,<=1.22.3",
         "scipy>=1.2.0,<2.0.0",
         "pandas>=1.0.0,<2.0.0",
         "tqdm>=4.33.0,<5.0.0",

--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -58,7 +58,11 @@ def metric_score(
     preds = to_int_label_array(preds) if preds is not None else None
 
     # Optionally filter out examples (e.g., abstain predictions or unknown labels)
-    label_dict: Dict[str, Optional[np.ndarray]] = {"golds": golds, "preds": preds, "probs": probs}
+    label_dict: Dict[str, Optional[np.ndarray]] = {
+        "golds": golds,
+        "preds": preds,
+        "probs": probs,
+    }
     if filter_dict:
         if set(filter_dict.keys()).difference(set(label_dict.keys())):
             raise ValueError(
@@ -66,7 +70,9 @@ def metric_score(
             )
         # Reassign filtered label_dict to a new variable to avoid
         # mypy error regarding change variable of invariant type
-        label_dict_filtered: Dict[str, np.ndarray] = filter_labels(label_dict, filter_dict)
+        label_dict_filtered: Dict[str, np.ndarray] = filter_labels(
+            label_dict, filter_dict
+        )
 
     # Confirm that required label sets are available
     func, label_names = METRICS[metric]

--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -58,21 +58,23 @@ def metric_score(
     preds = to_int_label_array(preds) if preds is not None else None
 
     # Optionally filter out examples (e.g., abstain predictions or unknown labels)
-    label_dict = {"golds": golds, "preds": preds, "probs": probs}
+    label_dict: Dict[str, Optional[np.ndarray]] = {"golds": golds, "preds": preds, "probs": probs}
     if filter_dict:
         if set(filter_dict.keys()).difference(set(label_dict.keys())):
             raise ValueError(
                 "filter_dict must only include keys in ['golds', 'preds', 'probs']"
             )
-        label_dict = filter_labels(label_dict, filter_dict)
+        # Reassign filtered label_dict to a new variable to avoid
+        # mypy error regarding change variable of invariant type
+        label_dict_filtered: Dict[str, np.ndarray] = filter_labels(label_dict, filter_dict)
 
     # Confirm that required label sets are available
     func, label_names = METRICS[metric]
     for label_name in label_names:
-        if label_dict[label_name] is None:
+        if label_dict_filtered[label_name] is None:
             raise ValueError(f"Metric {metric} requires access to {label_name}.")
 
-    label_sets = [label_dict[label_name] for label_name in label_names]
+    label_sets = [label_dict_filtered[label_name] for label_name in label_names]
     return func(*label_sets, **kwargs)
 
 

--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -74,16 +74,11 @@ def metric_score(
 
     # Confirm that required label sets are available
     func, label_names = METRICS[metric]
-    label_sets: List[np.ndarray] = []
     for label_name in label_names:
         if label_dict[label_name] is None:
             raise ValueError(f"Metric {metric} requires access to {label_name}.")
 
-        label_set: Optional[np.ndarray] = label_dict[label_name]
-        assert label_set is not None  # mypy
-
-        label_sets.append(label_set)
-
+    label_sets = [label_dict[label_name] for label_name in label_names]
     return func(*label_sets, **kwargs)
 
 

--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -68,8 +68,9 @@ def metric_score(
             raise ValueError(
                 "filter_dict must only include keys in ['golds', 'preds', 'probs']"
             )
-
-        label_dict = filter_labels(label_dict, filter_dict)
+        # label_dict is overwritten from type Dict[str, Optional[np.ndarray]]
+        # to Dict[str, np.ndarray]
+        label_dict = filter_labels(label_dict, filter_dict)  # type: ignore
 
     # Confirm that required label sets are available
     func, label_names = METRICS[metric]

--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -68,19 +68,21 @@ def metric_score(
             raise ValueError(
                 "filter_dict must only include keys in ['golds', 'preds', 'probs']"
             )
-        # Reassign filtered label_dict to a new variable to avoid
-        # mypy error regarding change variable of invariant type
-        label_dict_filtered: Dict[str, np.ndarray] = filter_labels(
-            label_dict, filter_dict
-        )
+
+        label_dict = filter_labels(label_dict, filter_dict)
 
     # Confirm that required label sets are available
     func, label_names = METRICS[metric]
+    label_sets: List[np.ndarray] = []
     for label_name in label_names:
-        if label_dict_filtered[label_name] is None:
+        if label_dict[label_name] is None:
             raise ValueError(f"Metric {metric} requires access to {label_name}.")
 
-    label_sets = [label_dict_filtered[label_name] for label_name in label_names]
+        label_set: Optional[np.ndarray] = label_dict[label_name]
+        assert label_set is not None  # mypy
+
+        label_sets.append(label_set)
+
     return func(*label_sets, **kwargs)
 
 

--- a/snorkel/classification/multitask_classifier.py
+++ b/snorkel/classification/multitask_classifier.py
@@ -368,7 +368,7 @@ class MultitaskClassifier(nn.Module):
             prob_dict[task_name] = torch.Tensor(np.array(prob_dict_list[task_name]))
 
         if return_preds:
-            pred_dict: Dict[str, torch.Tensor] = defaultdict(np.ndarray)
+            pred_dict: Dict[str, torch.Tensor] = defaultdict(torch.Tensor)
             for task_name, probs in prob_dict.items():
                 pred_dict[task_name] = torch.Tensor(probs_to_preds(probs.numpy()))
 

--- a/snorkel/synthetic/synthetic_data.py
+++ b/snorkel/synthetic/synthetic_data.py
@@ -52,7 +52,7 @@ def generate_simple_label_matrix(
     Y = np.random.choice(cardinality, n)
 
     # Generate the label matrix L
-    L = np.empty((n, m), dtype=int)
+    L: np.ndarray = np.empty((n, m), dtype=int)
     for i in range(n):
         for j in range(m):
             L[i, j] = np.random.choice(cardinality + 1, p=P[j, :, Y[i]]) - 1

--- a/snorkel/utils/core.py
+++ b/snorkel/utils/core.py
@@ -170,8 +170,10 @@ def filter_labels(
     """
     masks = []
     for label_name, filter_values in filter_dict.items():
-        if label_dict[label_name] is not None:
-            masks.append(_get_mask(label_dict[label_name], filter_values))
+        label_array: Optional[np.ndarray] = label_dict.get(label_name)
+        if label_array is not None:
+            # _get_mask requires not-null input
+            masks.append(_get_mask(label_array, filter_values))
     mask = (np.multiply(*masks) if len(masks) > 1 else masks[0]).squeeze()
 
     filtered = {}


### PR DESCRIPTION
## Description of proposed changes

According to https://github.com/snorkel-team/snorkel/issues/1689, numpy versions lower than 1.21 are not supported by the new Mac M1 chips. Bumping the upper bound of numpy to accommodate this.

## Related issue(s)

Fixes https://github.com/snorkel-team/snorkel/issues/1689

## Test plan

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [] All new and existing tests passed.
