### PR TITLE
Support m1 mac

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 #### ESSENTIAL LIBRARIES
 
 # General scientific computing
-numpy>=1.16.5,<1.20.0
+numpy>=1.16.5,<1.22.0
 scipy>=1.2.0,<2.0.0
 
 # Data storage and function application

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 #### ESSENTIAL LIBRARIES
 
 # General scientific computing
-numpy>=1.16.5,<1.22.0
+numpy>=1.16.5,<=1.22.3
 scipy>=1.2.0,<2.0.0
 
 # Data storage and function application
@@ -31,7 +31,7 @@ tensorboard>=2.0.0,<2.7.0
 
 # spaCy (NLP)
 spacy>=2.1.0,<3.0.0
-blis>=0.3.0,<0.5.0
+blis>=0.3.0,<=0.7.7
 
 # Dask (parallelism)
 dask[dataframe]>=2.1.0,<2.31.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "munkres>=1.0.6",
-        "numpy>=1.16.5,<1.20.0",
+        "numpy>=1.16.5,<1.22.0",
         "scipy>=1.2.0,<2.0.0",
         "pandas>=1.0.0,<2.0.0",
         "tqdm>=4.33.0,<5.0.0",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "munkres>=1.0.6",
-        "numpy>=1.16.5,<1.22.0",
+        "numpy>=1.16.5,<=1.22.3",
         "scipy>=1.2.0,<2.0.0",
         "pandas>=1.0.0,<2.0.0",
         "tqdm>=4.33.0,<5.0.0",

--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -58,21 +58,23 @@ def metric_score(
     preds = to_int_label_array(preds) if preds is not None else None
 
     # Optionally filter out examples (e.g., abstain predictions or unknown labels)
-    label_dict = {"golds": golds, "preds": preds, "probs": probs}
+    label_dict: Dict[str, Optional[np.ndarray]] = {"golds": golds, "preds": preds, "probs": probs}
     if filter_dict:
         if set(filter_dict.keys()).difference(set(label_dict.keys())):
             raise ValueError(
                 "filter_dict must only include keys in ['golds', 'preds', 'probs']"
             )
-        label_dict = filter_labels(label_dict, filter_dict)
+        # Reassign filtered label_dict to a new variable to avoid
+        # mypy error regarding change variable of invariant type
+        label_dict_filtered: Dict[str, np.ndarray] = filter_labels(label_dict, filter_dict)
 
     # Confirm that required label sets are available
     func, label_names = METRICS[metric]
     for label_name in label_names:
-        if label_dict[label_name] is None:
+        if label_dict_filtered[label_name] is None:
             raise ValueError(f"Metric {metric} requires access to {label_name}.")
 
-    label_sets = [label_dict[label_name] for label_name in label_names]
+    label_sets = [label_dict_filtered[label_name] for label_name in label_names]
     return func(*label_sets, **kwargs)
 
 

--- a/snorkel/classification/multitask_classifier.py
+++ b/snorkel/classification/multitask_classifier.py
@@ -368,7 +368,7 @@ class MultitaskClassifier(nn.Module):
             prob_dict[task_name] = torch.Tensor(np.array(prob_dict_list[task_name]))
 
         if return_preds:
-            pred_dict: Dict[str, torch.Tensor] = defaultdict(np.ndarray)
+            pred_dict: Dict[str, torch.Tensor] = defaultdict(torch.Tensor)
             for task_name, probs in prob_dict.items():
                 pred_dict[task_name] = torch.Tensor(probs_to_preds(probs.numpy()))
 

--- a/snorkel/synthetic/synthetic_data.py
+++ b/snorkel/synthetic/synthetic_data.py
@@ -52,7 +52,7 @@ def generate_simple_label_matrix(
     Y = np.random.choice(cardinality, n)
 
     # Generate the label matrix L
-    L = np.empty((n, m), dtype=int)
+    L: np.ndarray = np.empty((n, m), dtype=int)
     for i in range(n):
         for j in range(m):
             L[i, j] = np.random.choice(cardinality + 1, p=P[j, :, Y[i]]) - 1

--- a/snorkel/utils/core.py
+++ b/snorkel/utils/core.py
@@ -172,6 +172,7 @@ def filter_labels(
     for label_name, filter_values in filter_dict.items():
         label_array: Optional[np.ndarray] = label_dict.get(label_name)
         if label_array is not None:
+            # _get_mask requires not-null input
             masks.append(_get_mask(label_array, filter_values))
     mask = (np.multiply(*masks) if len(masks) > 1 else masks[0]).squeeze()
 

--- a/snorkel/utils/core.py
+++ b/snorkel/utils/core.py
@@ -170,8 +170,9 @@ def filter_labels(
     """
     masks = []
     for label_name, filter_values in filter_dict.items():
-        if label_dict[label_name] is not None:
-            masks.append(_get_mask(label_dict[label_name], filter_values))
+        label_array: Optional[np.ndarray] = label_dict.get(label_name)
+        if label_array is not None:
+            masks.append(_get_mask(label_array, filter_values))
     mask = (np.multiply(*masks) if len(masks) > 1 else masks[0]).squeeze()
 
     filtered = {}


### PR DESCRIPTION
## Description of proposed changes
Loosen versions for `numpy`, `blis` to support M1 Mac

## Related issue(s)
https://github.com/snorkel-team/snorkel/issues/1695

Fixes # (issue)
https://github.com/snorkel-team/snorkel/issues/1695

## Test plan
Need help on this

## Checklist

Need help on these? Just ask!
Need help to test py36 and py37 as they are hard to install on M1 Mac.
Need help on `tox -e spark`
Need help on CICD
Need help on what document to update
Need help on whether there should be new test cases

* [X] I have read the **CONTRIBUTING** document.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [X] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
** [X] `tox -e complex` runs and passes all test
** [ ] `tox -e spark` is currently failing with `Exception: Java gateway process exited before sending its port number`
* [ ] All new and existing tests passed.
** [X] `tox -e py38` passes
** [X] `tox -e complex` passes
** [X] `tox -e doctest` passes
** [X] `tox -e check` passes
** [X] `tox -e type` passes (all code changes are regarding this)
** [ ] `tox -e py36  # Run unit tests pytest in Python 3.6`
** [ ] `tox -e py37  # Run unit tests pytest in Python 3.7`
** [ ] `tox -e spark  # Run Spark-based tests (marked with @pytest.mark.spark)`
** [ ] `tox -e doc  # Build documentation with Sphinx`