### PR TITLE
Update release date for 0.9.9 and release instructions to be more consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [0.9.10]
 ### [Breaking Changes]
 ### [Added]
 ### [Changed]
 ### [Deprecated]
 ### [Removed]
 
-## [0.9.9] - 2022-04-14
+## [0.9.9] - 2022-07-28
 ### [Added]
 
 * PR #1690: Bump numpy version for Mac M1 compat

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,6 +28,7 @@ Then run `chmod 600 ./.pypirc` so only you can read/write.
        $ git pull origin main
 
 1. Add a new changelog entry for the release.
+
        ## [0.9.0]
        ### [Breaking Changes]
        ### [Added]

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -40,6 +40,7 @@ Then run `chmod 600 ./.pypirc` so only you can read/write.
 1. Update version to, e.g. 0.9.0 (remove the `+dev` label) in `snorkel/version.py`.
 
 1. Add a new changelog entry for the unreleased version:
+
        ## [Unreleased]
        ### [Breaking Changes]
        ### [Added]

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,7 +28,7 @@ Then run `chmod 600 ./.pypirc` so only you can read/write.
        $ git pull origin main
 
 1. Make sure `CHANGELOG.md` is up to date for the release: compare against PRs
-   merged since the last release & update top heading with release date.
+   merged since the last release & update top heading with the release version, e.g 0.9.0 and the release date.
 
 1. Update version to, e.g. 0.9.0 (remove the `+dev` label) in `snorkel/version.py`.
 
@@ -75,16 +75,6 @@ Then run `chmod 600 ./.pypirc` so only you can read/write.
 
 
 1. Update version to, e.g. 0.9.1+dev in `snorkel/version.py`.
-
-1. Add a new changelog entry for the unreleased version:
-
-       ## [Unreleased]
-       ## [0.9.1]
-       ### [Breaking Changes]
-       ### [Added]
-       ### [Changed]
-       ### [Deprecated]
-       ### [Removed]
 
 1. Commit these changes and create a PR:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,8 +27,15 @@ Then run `chmod 600 ./.pypirc` so only you can read/write.
    
        $ git pull origin main
 
-1. Make sure `CHANGELOG.md` is up to date for the release: compare against PRs
-   merged since the last release & update top heading with the release version, e.g 0.9.0 and the release date.
+1. Add a new changelog entry for the release.
+       ## [0.9.0]
+       ### [Breaking Changes]
+       ### [Added]
+       ### [Changed]
+       ### [Deprecated]
+       ### [Removed]
+  Make sure `CHANGELOG.md` is up to date for the release: compare against PRs
+  merged since the last release.
 
 1. Update version to, e.g. 0.9.0 (remove the `+dev` label) in `snorkel/version.py`.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -40,14 +40,6 @@ Then run `chmod 600 ./.pypirc` so only you can read/write.
 
 1. Update version to, e.g. 0.9.0 (remove the `+dev` label) in `snorkel/version.py`.
 
-1. Add a new changelog entry for the unreleased version:
-
-       ##  [Unreleased]
-       ### [Breaking Changes]
-       ### [Added]
-       ### [Changed]
-       ### [Deprecated]
-       ### [Removed]
 
 1. Commit these changes and create a PR:
 
@@ -92,6 +84,15 @@ Then run `chmod 600 ./.pypirc` so only you can read/write.
 
 
 1. Update version to, e.g. 0.9.1+dev in `snorkel/version.py`.
+
+1. Add a new changelog entry for the unreleased version in `CHANGELOG.md`:
+
+       ##  [Unreleased]
+       ### [Breaking Changes]
+       ### [Added]
+       ### [Changed]
+       ### [Deprecated]
+       ### [Removed]
 
 1. Commit these changes and create a PR:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,6 +39,14 @@ Then run `chmod 600 ./.pypirc` so only you can read/write.
 
 1. Update version to, e.g. 0.9.0 (remove the `+dev` label) in `snorkel/version.py`.
 
+1. Add a new changelog entry for the unreleased version:
+       ## [Unreleased]
+       ### [Breaking Changes]
+       ### [Added]
+       ### [Changed]
+       ### [Deprecated]
+       ### [Removed]
+
 1. Commit these changes and create a PR:
 
        git checkout -b release-v0.9.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -41,7 +41,7 @@ Then run `chmod 600 ./.pypirc` so only you can read/write.
 
 1. Add a new changelog entry for the unreleased version:
 
-       ## [Unreleased]
+       ##  [Unreleased]
        ### [Breaking Changes]
        ### [Added]
        ### [Changed]

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,7 +29,7 @@ Then run `chmod 600 ./.pypirc` so only you can read/write.
 
 1. Add a new changelog entry for the release.
 
-       ## [0.9.0]
+       ##  [0.9.0]
        ### [Breaking Changes]
        ### [Added]
        ### [Changed]


### PR DESCRIPTION
## Description of proposed changes
This PR updates the release instructions to only add the release version when we are about to cut a release not right after the previous one was cut
## Related issue(s)

Fixes # (issue)

## Test plan

## Checklist

Need help on these? Just ask!

* [ ] I have read the **CONTRIBUTING** document.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [ ] All new and existing tests passed.
