### PR TITLE
Fix career page redirect in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Announcement
 
-**The Snorkel team is now focusing their efforts on Snorkel Flow, an end-to-end AI application development platform based on the core ideas behind Snorkel—you can check it out [here](https://snorkel.ai) or [join us](www.snorkel.ai/careers) in building it!**
+**The Snorkel team is now focusing their efforts on Snorkel Flow, an end-to-end AI application development platform based on the core ideas behind Snorkel—you can check it out [here](https://snorkel.ai) or [join us](https://www.snorkel.ai/careers) in building it!**
 
 The [Snorkel project](https://snorkel.ai/how-to-use-snorkel-to-build-ai-applications/) started at Stanford in 2015 with a simple technical bet: that it would increasingly be the **training data**, not the models, algorithms, or infrastructure, that decided whether a machine learning project succeeded or failed. Given this premise, we set out to explore the radical idea that you could bring mathematical and systems structure to the messy and often entirely manual process of training data creation and management, starting by empowering users to **programmatically label, build, and manage** training data.
 


### PR DESCRIPTION
www.snorkel.ai/careers -> https://www.snorkel.ai/careers

## Description of proposed changes
The old link used to redirect to https://github.com/snorkel-team/snorkel/blob/main/www.snorkel.ai/careers

## Related issue(s)

Fixes # (issue)

## Test plan

## Checklist

Need help on these? Just ask!

* [x] I have read the **CONTRIBUTING** document.
* [x] I have updated the documentation accordingly.
* [N/A] I have added tests to cover my changes.
* [N/A] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [N/A] All new and existing tests passed.
